### PR TITLE
HotFix: Fix an issue parsing event timestamps

### DIFF
--- a/core/services.py
+++ b/core/services.py
@@ -225,7 +225,11 @@ def is_event_too_old(event):
     timestamp = event._attributes.get("time")
     if not timestamp:
         return False
-    event_time = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
+    try:  # The timestamp does not always include the microseconds part
+        event_time = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        event_time = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    event_time = event_time.replace(tzinfo=timezone.utc)
     event_age_seconds = (datetime.now(timezone.utc) - event_time).seconds
     # Ignore events that are too old
     return event_age_seconds > settings.MAX_EVENT_AGE_SECONDS


### PR DESCRIPTION
This fixes an issue while parsing the timestamp of cloud events received in the serverless dispatchers. In a few ocations the timestamp comes in a different format without the microseconds part and that was causing a parse error. This fix is to handle the error and support both formats.