### PR TITLE
SIK-2270: Update gundi-client version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,9 +3,9 @@ pydantic==1.10.4
 walrus==0.9.2
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
 https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.4.4-alpha/cdip_connector-1.4.4-py3-none-any.whl
-gundi-core==1.2.0
+gundi-core==1.2.1
 gundi-client==1.0.1
-gundi-client-v2==2.1.0
+gundi-client-v2==2.1.1
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,9 +131,9 @@ gundi-client==1.0.1
     # via
     #   -r requirements.in
     #   cdip-connector
-gundi-client-v2==2.1.0
+gundi-client-v2==2.1.1
     # via -r requirements.in
-gundi-core==1.2.0
+gundi-core==1.2.1
     # via
     #   -r requirements.in
     #   cdip-connector

--- a/test_local.sh
+++ b/test_local.sh
@@ -3,23 +3,23 @@ curl localhost:8080 \
   -H "Content-Type: application/json" \
   -H "ce-id: 123451234512345" \
   -H "ce-specversion: 1.0" \
-  -H "ce-time: 2023-07-14T10:01:56.789Z" \
+  -H "ce-time: 2023-07-31T10:01:56.789Z" \
   -H "ce-type: google.cloud.pubsub.topic.v1.messagePublished" \
   -H "ce-source: //pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC" \
   -d '{
       "message": {
-        "data":"eyJmaWxlX3BhdGgiOiAiYXR0YWNobWVudHMvZjFhODg5NGItZmYyZS00Mjg2LTkwYTAtOGYxNzMwM2U5MWRmXzIwMjMtMDYtMjYtMTA1M19sZW9wYXJkLmpwZyJ9",
+        "data":"eyJ0aXRsZSI6ICJXaWxkZG9nIERldGVjdGVkIiwgImV2ZW50X3R5cGUiOiBudWxsLCAiZXZlbnRfZGV0YWlscyI6IHsic2l0ZV9uYW1lIjogIkNhbWVyYTJNIiwgInNwZWNpZXMiOiAiV2lsZGRvZyIsICJ0YWdzIjogWyJhZHVsdCIsICJtYWxlIl0sICJhbmltYWxfY291bnQiOiAxfSwgInRpbWUiOiAiMjAyMy0wNy0zMSAxNDowODowMCswMDowMCIsICJsb2NhdGlvbiI6IHsibG9uZ2l0dWRlIjogLTcyLjcwNDQzNSwgImxhdGl0dWRlIjogLTUxLjY4ODY0OX0sICIiOiBudWxsfQ==",
         "attributes":{
           "gundi_version":"v2",
           "provider_key":"ddd0946d-15b0-4308-b93d-e0470b6d33b6",
-          "gundi_id":"e6795790-4a5f-4d47-ac93-de7d7713698b",
-          "related_to":"92855c84-572b-42ae-8183-8deb33fdd476",
-          "stream_type":"att",
-          "source_id":"None",
-          "external_source_id":"None",
+          "gundi_id":"35a9c36b-e566-4365-af87-c0caa9323b3d",
+          "related_to": "None",
+          "stream_type":"ev",
+          "source_id":"afa0d606-c143-4705-955d-68133645db6d",
+          "external_source_id":"Xyz123",
           "destination_id":"338225f3-91f9-4fe1-b013-353a229ce504",
           "data_provider_id":"ddd0946d-15b0-4308-b93d-e0470b6d33b6",
-          "annotations":"null",
+          "annotations":"{}",
           "tracing_context":"{}"
         }
       },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from gundi_core import events as system_events
 from gcloud.aio import pubsub
 from core import settings
 
+
 def async_return(result):
     f = asyncio.Future()
     f.set_result(result)
@@ -126,11 +127,12 @@ def mock_pubsub_client(mocker, observation_delivered_pubsub_message, gcp_pubsub_
 @pytest.fixture
 def observation_delivery_failure_pubsub_message():
     return pubsub.PubsubMessage(
-        b'{"event_id": "a13c5742-8199-404b-a41b-f520d7462d74", "timestamp": "2023-07-13 14:17:13.323863+00:00", "schema_version": "v1", "payload": {"gundi_id": "9f86ae28-99c4-473f-be13-fb92bd0bc341", "related_to": null, "external_id": null, "data_provider_id": "ddd0946d-15b0-4308-b93d-e0470b6d33b6", "destination_id": "338225f3-91f9-4fe1-b013-353a229ce504", "delivered_at": "2023-07-13 14:17:13.323706+00:00"}, "event_type": "ObservationDeliveryFailed"}'    )
+        b'{"event_id": "a13c5742-8199-404b-a41b-f520d7462d74", "timestamp": "2023-07-13 14:17:13.323863+00:00", "schema_version": "v1", "payload": {"gundi_id": "9f86ae28-99c4-473f-be13-fb92bd0bc341", "related_to": null, "external_id": null, "data_provider_id": "ddd0946d-15b0-4308-b93d-e0470b6d33b6", "destination_id": "338225f3-91f9-4fe1-b013-353a229ce504", "delivered_at": "2023-07-13 14:17:13.323706+00:00"}, "event_type": "ObservationDeliveryFailed"}')
 
 
 @pytest.fixture
-def mock_pubsub_client_with_observation_delivery_failure(mocker, observation_delivery_failure_pubsub_message, gcp_pubsub_publish_response):
+def mock_pubsub_client_with_observation_delivery_failure(mocker, observation_delivery_failure_pubsub_message,
+                                                         gcp_pubsub_publish_response):
     mock_client = mocker.MagicMock()
     mock_publisher = mocker.MagicMock()
     mock_publisher.publish.return_value = async_return(gcp_pubsub_publish_response)
@@ -467,19 +469,11 @@ def cameratrap_event_as_cloud_event():
 @pytest.fixture
 def mock_gundi_client_v2(
         mocker,
-        connection_v2,
         destination_integration_v2,
-        route_v2,
 ):
     mock_client = mocker.MagicMock()
-    mock_client.get_connection_details.return_value = async_return(
-        connection_v2
-    )
     mock_client.get_integration_details.return_value = async_return(
         destination_integration_v2
-    )
-    mock_client.get_route_details.return_value = async_return(
-        route_v2
     )
     mock_client.__aenter__.return_value = mock_client
     return mock_client
@@ -495,81 +489,41 @@ def mock_gundi_client_v2_class(mocker, mock_gundi_client_v2):
 @pytest.fixture
 def destination_integration_v2():
     return schemas_v2.Integration.parse_obj(
-        {
-            'id': '338225f3-91f9-4fe1-b013-353a229ce504',
-            'name': 'ER Load Testing',
-            'base_url': 'https://gundi-load-testing.pamdas.org', 'enabled': True,
-            'type': {'id': '46c66a61-71e4-4664-a7f2-30d465f87aae', 'name': 'EarthRanger',
-                     'description': 'Integration type for Earth Ranger Sites', 'actions': [
-                    {'id': '42ec4163-2f40-43fc-af62-bca1db77c06c', 'type': 'auth', 'name': 'Authenticate',
-                     'value': 'auth', 'description': 'Authenticate against Earth Ranger',
-                     'schema': {'type': 'object', 'required': ['token'], 'properties': {'token': {'type': 'string'}}}},
-                    {'id': '016c2098-f494-40ec-a595-710b314d5eaf', 'type': 'pull', 'name': 'Pull Positions',
-                     'value': 'pull_positions', 'description': 'Pull position data from an Earth Ranger site',
-                     'schema': {'type': 'object', 'required': ['endpoint'],
-                                'properties': {'endpoint': {'type': 'string'}}}},
-                    {'id': '8886bb71-9aca-425a-881f-7fe0b2dba4f5', 'type': 'push', 'name': 'Push Events',
-                     'value': 'push_events', 'description': 'EarthRanger sites support sending Events (a.k.a Reports)',
-                     'schema': {}},
-                    {'id': 'abe0cf50-fbc7-4810-84fd-53fb75020a55', 'type': 'push', 'name': 'Push Positions',
-                     'value': 'push_positions', 'description': 'Push position data to an Earth Ranger site',
-                     'schema': {'type': 'object', 'required': ['endpoint'],
-                                'properties': {'endpoint': {'type': 'string'}}}}]},
-            'owner': {'id': '12d1b0fc-69fe-408b-afc5-8f54872730c1', 'name': 'Test Organization', 'description': ''},
-            'configurations': [
-                {'id': '013ea7ce-4944-4f7e-8a2f-e5338b3741ce', 'integration': '228225f3-91f9-4fe1-b013-353a229ce505',
-                 'action': {'id': '43ec4163-2f40-43fc-af62-bca1db77c06b', 'type': 'auth', 'name': 'Authenticate',
-                            'value': 'auth'}, 'data': {'token': '0890d87681cd1d01ad07c2d0f57d15d6079ae7d7'}},
-                {'id': '5de91c7b-f28a-4ce7-8137-273ac10674d2', 'integration': '228225f3-91f9-4fe1-b013-353a229ce505',
-                 'action': {'id': 'aae0cf50-fbc7-4810-84fd-53fb75020a43', 'type': 'push', 'name': 'Push Positions',
-                            'value': 'push_positions'}, 'data': {'endpoint': 'api/v1/positions'}},
-                {'id': '7947b19e-1d2d-4ca3-bd6c-74976ae1de68', 'integration': '228225f3-91f9-4fe1-b013-353a229ce505',
-                 'action': {'id': '036c2098-f494-40ec-a595-710b314d5ea5', 'type': 'pull', 'name': 'Pull Positions',
-                            'value': 'pull_positions'}, 'data': {'endpoint': 'api/v1/positions'}}],
-            'additional': {'topic': 'destination-v2-228225f3-91f9-4fe1-b013-353a229ce505-dev', 'broker': 'gcp_pubsub'},
-            'default_route': {'id': '38dd8ec2-b3ee-4c31-940e-b6cc9c1f4326', 'name': 'Mukutan - Load Testing'},
-            'status': {'id': 'mockid-b16a-4dbd-ad32-197c58aeef59', 'is_healthy': True,
-                       'details': 'Last observation has been delivered with success.',
-                       'observation_delivered_24hrs': 50231,
-                       'last_observation_delivered_at': '2023-03-31T11:20:00+0200'}
-        }
-    )
-
-
-@pytest.fixture
-def connection_v2():
-    return schemas_v2.Connection.parse_obj(
-        {
-            'id': 'bbd0946d-15b0-4308-b93d-e0470b6c33b7',
-            'provider': {'id': 'bbd0946d-15b0-4308-b93d-e0470b6c33b7', 'name': 'Trap Tagger', 'type': 'traptagger',
-                         'base_url': 'https://test.traptagger.com', 'status': 'healthy'}, 'destinations': [
-            {'id': '338225f3-91f9-4fe1-b013-353a229ce504', 'name': 'ER Load Testing', 'type': 'earth_ranger',
-             'base_url': 'https://gundi-load-testing.pamdas.org', 'status': 'healthy'}],
-            'routing_rules': [{'id': '945897f9-1ef2-7d55-9c6c-ea2663380ca5', 'name': 'TrapTagger Default Route'}],
-            'default_route': {'id': '945897f9-1ef2-7d55-9c6c-ea2663380ca5', 'name': 'TrapTagger Default Route'},
-            'owner': {'id': 'b3d1b0fc-69fe-408b-afc5-7f54872730c1', 'name': 'Test Organization', 'description': ''},
-            'status': 'healthy'
-        }
-    )
-
-
-@pytest.fixture
-def route_v2():
-    return schemas_v2.Route.parse_obj(
-        {
-            'id': '775897f9-1ef2-4d10-9c6c-ea2663380c5b', 'name': 'TrapTagger Default Route',
-            'owner': 'b3d1b0fc-69fe-408b-afc5-7f54872730c1', 'data_providers': [
-            {'id': 'ccd0946d-15b0-4308-b93d-e0470b6d33b5', 'name': 'Trap Tagger', 'type': 'traptagger',
-             'base_url': 'https://test.traptagger.com', 'status': 'healthy'}], 'destinations': [
-            {'id': '228225f3-91f9-4fe1-b013-353a229ce512', 'name': 'ER Load Testing', 'type': 'earth_ranger',
-             'base_url': 'https://gundi-load-testing.pamdas.org', 'status': 'healthy'}],
-            'configuration': {'id': '5b3e3e73-94ad-42cb-a765-09a7193ae0b6',
-                              'name': 'Trap Tagger to ER - Event Type Mapping', 'data': {'field_mappings': {
-                    'ddd0946d-15b0-4308-b93d-e0470b6d33b6': {'ev': {'558225f3-91f9-4fe1-b013-353a229ce503': {
-                        'map': {'Leopard': 'leopard_sighting', 'wild_dog': 'wild_dog_sighting'},
-                        'provider_field': 'event_details__species', 'destination_field': 'event_type'}}}}}},
-            'additional': {}
-        }
+        {'id': '338225f3-91f9-4fe1-b013-353a229ce504', 'name': 'ER Load Testing',
+         'base_url': 'https://gundi-load-testing.pamdas.org', 'enabled': True,
+         'type': {'id': '45c66a61-71e4-4664-a7f2-30d465f87aa6', 'name': 'EarthRanger', 'value': 'earth_ranger',
+                  'description': 'Integration type for Earth Ranger Sites', 'actions': [
+                 {'id': '43ec4163-2f40-43fc-af62-bca1db77c06b', 'type': 'auth', 'name': 'Authenticate', 'value': 'auth',
+                  'description': 'Authenticate against Earth Ranger',
+                  'schema': {'type': 'object', 'required': ['token'], 'properties': {'token': {'type': 'string'}}}},
+                 {'id': '036c2098-f494-40ec-a595-710b314d5ea5', 'type': 'pull', 'name': 'Pull Positions',
+                  'value': 'pull_positions', 'description': 'Pull position data from an Earth Ranger site',
+                  'schema': {'type': 'object', 'required': ['endpoint'],
+                             'properties': {'endpoint': {'type': 'string'}}}},
+                 {'id': '9286bb71-9aca-425a-881f-7fe0b2dba4f4', 'type': 'push', 'name': 'Push Events',
+                  'value': 'push_events', 'description': 'EarthRanger sites support sending Events (a.k.a Reports)',
+                  'schema': {}},
+                 {'id': 'aae0cf50-fbc7-4810-84fd-53fb75020a43', 'type': 'push', 'name': 'Push Positions',
+                  'value': 'push_positions', 'description': 'Push position data to an Earth Ranger site',
+                  'schema': {'type': 'object', 'required': ['endpoint'],
+                             'properties': {'endpoint': {'type': 'string'}}}}]},
+         'owner': {'id': 'e2d1b0fc-69fe-408b-afc5-7f54872730c0', 'name': 'Test Organization', 'description': ''},
+         'configurations': [
+             {'id': '013ea7ce-4944-4f7e-8a2f-e5338b3741ce', 'integration': '338225f3-91f9-4fe1-b013-353a229ce504',
+              'action': {'id': '43ec4163-2f40-43fc-af62-bca1db77c06b', 'type': 'auth', 'name': 'Authenticate',
+                         'value': 'auth'}, 'data': {'token': '1190d87681cd1d01ad07c2d0f57d15d6079ae7ab'}},
+             {'id': '5de91c7b-f28a-4ce7-8137-273ac10674d2', 'integration': '338225f3-91f9-4fe1-b013-353a229ce504',
+              'action': {'id': 'aae0cf50-fbc7-4810-84fd-53fb75020a43', 'type': 'push', 'name': 'Push Positions',
+                         'value': 'push_positions'}, 'data': {'endpoint': 'api/v1/positions'}},
+             {'id': '7947b19e-1d2d-4ca3-bd6c-74976ae1de68', 'integration': '338225f3-91f9-4fe1-b013-353a229ce504',
+              'action': {'id': '036c2098-f494-40ec-a595-710b314d5ea5', 'type': 'pull', 'name': 'Pull Positions',
+                         'value': 'pull_positions'}, 'data': {'endpoint': 'api/v1/positions'}}],
+         'additional': {'topic': 'destination-v2-338225f3-91f9-4fe1-b013-353a229ce504-dev', 'broker': 'gcp_pubsub'},
+         'default_route': {'id': '38dd8ec2-b3ee-4c31-940e-b6cc9c1f4326', 'name': 'Mukutan - Load Testing'},
+         'status': {'id': 'mockid-b16a-4dbd-ad32-197c58aeef59', 'is_healthy': True,
+                    'details': 'Last observation has been delivered with success.',
+                    'observation_delivered_24hrs': 50231, 'last_observation_delivered_at': '2023-03-31T11:20:00+0200'}
+         }
     )
 
 


### PR DESCRIPTION
What does this PR do?
- Update dependencies to use the latest version of gundi client and gundi-core, after API changes
- Update unit tests

Relevant link(s)
[SIK-2270](https://allenai.atlassian.net/browse/SIK-2270)

[SIK-2270]: https://allenai.atlassian.net/browse/SIK-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ