### PR TITLE
SIK-2364: Update gundi-client-v2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_cl
 https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.4.4-alpha/cdip_connector-1.4.4-py3-none-any.whl
 gundi-core==1.2.1
 gundi-client==1.0.1
-gundi-client-v2==2.1.1
+gundi-client-v2==2.1.2
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,7 +131,7 @@ gundi-client==1.0.1
     # via
     #   -r requirements.in
     #   cdip-connector
-gundi-client-v2==2.1.1
+gundi-client-v2==2.1.2
     # via -r requirements.in
 gundi-core==1.2.1
     # via


### PR DESCRIPTION
### What does this PR do?
- Update the gundi client v2 to the latest version after we removed `/api/ `from the URL path
- This is covered by regression tests.

### Relevant link(s)
[SIK-2364](https://allenai.atlassian.net/browse/SIK-2364)

[SIK-2364]: https://allenai.atlassian.net/browse/SIK-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ