### PR TITLE
GUNDI-3095: Upgrade gundi client version to handle login redirects

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 # Wrapper to be able to run the async function
 @cloud_event
 def main(event):
-    print(f"Event received:\n{event}")
+    print(f"CloudEvent received:\n{event}")
     asyncio.run(process_event(event))
-    print(f"Event processed successfully.")
+    print(f"CloudEvent processed successfully.")
     return {}

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ walrus==0.9.2
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
 https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.4.4-alpha/cdip_connector-1.4.4-py3-none-any.whl
 gundi-core==1.2.6
-gundi-client==1.0.1
+gundi-client==1.0.2
 gundi-client-v2==2.1.2
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,7 +127,7 @@ grpcio-status==1.56.0
     # via
     #   google-api-core
     #   google-cloud-pubsub
-gundi-client==1.0.1
+gundi-client==1.0.2
     # via
     #   -r requirements.in
     #   cdip-connector

--- a/tests/test_process_observations.py
+++ b/tests/test_process_observations.py
@@ -8,18 +8,18 @@ from core.errors import ReferenceDataError
 async def test_process_position_successfully(
     mocker,
     mock_cache,
-    mock_gundi_client,
+    mock_gundi_client_class,
     mock_erclient_class,
     mock_pubsub_client,
     position_as_cloud_event,
     outbound_configuration_gcp_pubsub,
 ):
-    # Mock external dependencies
-    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+    # Override the mocked config to one that uses pubsub broker
+    mock_gundi_client_class.return_value.get_outbound_integration_list.return_value = async_return(
         [outbound_configuration_gcp_pubsub]
     )
     mocker.patch("core.utils._cache_db", mock_cache)
-    mocker.patch("core.utils.portal", mock_gundi_client)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class)
     mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
     await process_event(position_as_cloud_event)
     assert mock_erclient_class.called
@@ -30,18 +30,18 @@ async def test_process_position_successfully(
 async def test_process_geoevent_successfully(
     mocker,
     mock_cache,
-    mock_gundi_client,
+    mock_gundi_client_class,
     mock_erclient_class,
     mock_pubsub_client,
     geoevent_as_cloud_event,
     outbound_configuration_gcp_pubsub,
 ):
     # Mock external dependencies
-    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+    mock_gundi_client_class.get_outbound_integration_list.return_value = async_return(
         [outbound_configuration_gcp_pubsub]
     )
     mocker.patch("core.utils._cache_db", mock_cache)
-    mocker.patch("core.utils.portal", mock_gundi_client)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class)
     mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
     await process_event(geoevent_as_cloud_event)
     assert mock_erclient_class.called
@@ -52,7 +52,7 @@ async def test_process_geoevent_successfully(
 async def test_process_cameratrap_event_successfully(
     mocker,
     mock_cache,
-    mock_gundi_client,
+    mock_gundi_client_class,
     mock_erclient_class,
     mock_pubsub_client,
     mock_get_cloud_storage,
@@ -60,11 +60,11 @@ async def test_process_cameratrap_event_successfully(
     outbound_configuration_gcp_pubsub,
 ):
     # Mock external dependencies
-    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+    mock_gundi_client_class.return_value.get_outbound_integration_list.return_value = async_return(
         [outbound_configuration_gcp_pubsub]
     )
     mocker.patch("core.utils._cache_db", mock_cache)
-    mocker.patch("core.utils.portal", mock_gundi_client)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class)
     mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
     mocker.patch("core.dispatchers.get_cloud_storage", mock_get_cloud_storage)
     #get_cloud_storage
@@ -77,14 +77,33 @@ async def test_process_cameratrap_event_successfully(
 async def test_raise_exception_on_portal_connection_error(
     mocker,
     mock_cache,
-    mock_gundi_client_with_client_connector_error,
+    mock_gundi_client_class_with_client_connect_error,
     mock_erclient_class,
     mock_pubsub_client,
     position_as_cloud_event,
     outbound_configuration_gcp_pubsub,
 ):
     mocker.patch("core.utils._cache_db", mock_cache)
-    mocker.patch("core.utils.portal", mock_gundi_client_with_client_connector_error)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class_with_client_connect_error)
+    mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
+    with pytest.raises(Exception) as e_info:
+        await process_event(position_as_cloud_event)
+    # Check that the right exception type is raised to activate the retry mechanism
+    assert e_info.type == ReferenceDataError
+
+
+@pytest.mark.asyncio
+async def test_raise_exception_on_portal_500_error(
+    mocker,
+    mock_cache,
+    mock_gundi_client_class_with_with_500_error,
+    mock_erclient_class,
+    mock_pubsub_client,
+    position_as_cloud_event,
+    outbound_configuration_gcp_pubsub,
+):
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class_with_with_500_error)
     mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
     with pytest.raises(Exception) as e_info:
         await process_event(position_as_cloud_event)
@@ -96,18 +115,18 @@ async def test_raise_exception_on_portal_connection_error(
 async def test_process_position_with_faulty_cache_successfully(
     mocker,
     mock_cache_with_connection_error,
-    mock_gundi_client,
+    mock_gundi_client_class,
     mock_erclient_class,
     mock_pubsub_client,
     position_as_cloud_event,
     outbound_configuration_gcp_pubsub,
 ):
     # Mock external dependencies
-    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+    mock_gundi_client_class.return_value.get_outbound_integration_list.return_value = async_return(
         [outbound_configuration_gcp_pubsub]
     )
     mocker.patch("core.utils._cache_db", mock_cache_with_connection_error)
-    mocker.patch("core.utils.portal", mock_gundi_client)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class)
     mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
     await process_event(position_as_cloud_event)
     assert mock_erclient_class.called
@@ -118,18 +137,18 @@ async def test_process_position_with_faulty_cache_successfully(
 async def test_process_geoevent_with_faulty_cache_successfully(
     mocker,
     mock_cache_with_connection_error,
-    mock_gundi_client,
+    mock_gundi_client_class,
     mock_erclient_class,
     mock_pubsub_client,
     geoevent_as_cloud_event,
     outbound_configuration_gcp_pubsub,
 ):
     # Mock external dependencies
-    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+    mock_gundi_client_class.return_value.get_outbound_integration_list.return_value = async_return(
         [outbound_configuration_gcp_pubsub]
     )
     mocker.patch("core.utils._cache_db", mock_cache_with_connection_error)
-    mocker.patch("core.utils.portal", mock_gundi_client)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class)
     mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
     await process_event(geoevent_as_cloud_event)
     assert mock_erclient_class.called
@@ -140,7 +159,7 @@ async def test_process_geoevent_with_faulty_cache_successfully(
 async def test_process_cameratrap_event_with_faulty_cache_successfully(
     mocker,
     mock_cache_with_connection_error,
-    mock_gundi_client,
+    mock_gundi_client_class,
     mock_erclient_class,
     mock_pubsub_client,
     mock_get_cloud_storage,
@@ -148,11 +167,11 @@ async def test_process_cameratrap_event_with_faulty_cache_successfully(
     outbound_configuration_gcp_pubsub,
 ):
     # Mock external dependencies
-    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+    mock_gundi_client_class.return_value.get_outbound_integration_list.return_value = async_return(
         [outbound_configuration_gcp_pubsub]
     )
     mocker.patch("core.utils._cache_db", mock_cache_with_connection_error)
-    mocker.patch("core.utils.portal", mock_gundi_client)
+    mocker.patch("core.utils.PortalApi", mock_gundi_client_class)
     mocker.patch("core.dispatchers.AsyncERClient", mock_erclient_class)
     mocker.patch("core.dispatchers.get_cloud_storage", mock_get_cloud_storage)
     #get_cloud_storage


### PR DESCRIPTION
### What does this PR do?
- Upgrades the gundi client v1 to version 1.0.2 so it refreshes expired tokens on login redirections. This is to reduce retries and then reduce latency as described in [GUNDI-3095](https://allenai.atlassian.net/browse/GUNDI-3095)
- Refactors the dispatcher's code for v1 observations to use the new gundi-client version
- Adds a few more uni tests for cases where the portal returns a bad status
- Improve some log messages for cases where the portal returns a bad status

### Relevant link(s)
[GUNDI-3095](https://allenai.atlassian.net/browse/GUNDI-3095)

[GUNDI-3095]: https://allenai.atlassian.net/browse/GUNDI-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GUNDI-3095]: https://allenai.atlassian.net/browse/GUNDI-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ