### PR TITLE
GUNDI-3095: Fix a path issue in dispatchers v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
     branches:
         - main
         - 'release-**'
-        - 'gundi-3095-fix-dispatchers-v1'
 
 jobs:
   vars:


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in dispatchers v1 where the path part of the ER endpoint was accidentally being removed (the `/api/v1.0/` part) in dispatchers v1. Force the path to the right one, as the service was built for ER API v1 and that shouldn't be configurable.

### Relevant link(s)
[GUNDI-3095](https://allenai.atlassian.net/browse/GUNDI-3095)

[GUNDI-3095]: https://allenai.atlassian.net/browse/GUNDI-3095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ