### PR TITLE
GUNDI-4291: Support ER Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Serverless dispatcher (CloudEvent Functions) to send observations to EarthRanger.
 
 
-Supported observation types: Positions, GeoEvents and  CameraTrap Events
+Supported observation types: Positions, Events, Event Updates, Attachments, and Text Messages
 
 ## Development
 ### Create python virtual environment with python 3.7+

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -272,13 +272,13 @@ async def handle_er_observation(event: AttachmentTransformedER, attributes: dict
         return await dispatch_transformed_observation_v2(observation=event.payload, attributes=attributes)
 
 
-async def handle_er_message(message: MessageTransformedER, attributes: dict):
+async def handle_er_message(event: MessageTransformedER, attributes: dict):
     # Trace observations with Open Telemetry
     with tracing.tracer.start_as_current_span(
             "er_dispatcher.handle_er_message", kind=SpanKind.CONSUMER
     ) as current_span:
-        current_span.set_attribute("payload", repr(message.payload))
-        return await dispatch_transformed_observation_v2(observation=message.payload, attributes=attributes)
+        current_span.set_attribute("payload", repr(event.payload))
+        return await dispatch_transformed_observation_v2(observation=event.payload, attributes=attributes)
 
 event_schemas = {
     "EventTransformedER": EventTransformedER,

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -7,7 +7,8 @@ from gundi_core.events.transformers import (
     EventTransformedER,
     EventUpdateTransformedER,
     AttachmentTransformedER,
-    ObservationTransformedER
+    ObservationTransformedER,
+    MessageTransformedER
 )
 from core import tracing, dispatchers, settings
 from core.errors import ReferenceDataError, DispatcherException
@@ -271,11 +272,20 @@ async def handle_er_observation(event: AttachmentTransformedER, attributes: dict
         return await dispatch_transformed_observation_v2(observation=event.payload, attributes=attributes)
 
 
+async def handle_er_message(message: MessageTransformedER, attributes: dict):
+    # Trace observations with Open Telemetry
+    with tracing.tracer.start_as_current_span(
+            "er_dispatcher.handle_er_message", kind=SpanKind.CONSUMER
+    ) as current_span:
+        current_span.set_attribute("payload", repr(message.payload))
+        return await dispatch_transformed_observation_v2(observation=message.payload, attributes=attributes)
+
 event_schemas = {
     "EventTransformedER": EventTransformedER,
     "EventUpdateTransformedER": EventUpdateTransformedER,
     "AttachmentTransformedER": AttachmentTransformedER,
     "ObservationTransformedER": ObservationTransformedER,
+    "MessageTransformedER": MessageTransformedER
 }
 
 event_handlers = {
@@ -283,4 +293,5 @@ event_handlers = {
     "EventUpdateTransformedER": handle_er_event_update,
     "AttachmentTransformedER": handle_er_attachment,
     "ObservationTransformedER": handle_er_observation,
+    "MessageTransformedER": handle_er_message
 }

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ functions-framework==3.*
 walrus==0.9.2
 https://github.com/PADAS/er-client/releases/download/v1.4.1/earthranger_client-1.4.1-py3-none-any.whl
 https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.4.4-alpha/cdip_connector-1.4.4-py3-none-any.whl
-gundi-core==1.9.0
+gundi-core==1.11.1
 gundi-client==1.0.4
 gundi-client-v2==2.3.8
 opentelemetry-api==1.14.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 functions-framework==3.*
 walrus==0.9.2
-https://github.com/PADAS/er-client/releases/download/v1.4.1/earthranger_client-1.4.1-py3-none-any.whl
+https://github.com/PADAS/er-client/releases/download/v1.5.0/earthranger_client-1.5.0-py3-none-any.whl
 https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.4.4-alpha/cdip_connector-1.4.4-py3-none-any.whl
 gundi-core==1.11.1
 gundi-client==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -133,7 +133,7 @@ gundi-client==1.0.4
     #   cdip-connector
 gundi-client-v2==2.3.8
     # via -r requirements.in
-gundi-core==1.9.0
+gundi-core==1.11.1
     # via
     #   -r requirements.in
     #   cdip-connector

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ deprecated==1.2.14
     # via opentelemetry-api
 deprecation==2.1.0
     # via cloudevents
-earthranger-client @ https://github.com/PADAS/er-client/releases/download/v1.4.1/earthranger_client-1.4.1-py3-none-any.whl
+earthranger-client @ https://github.com/PADAS/er-client/releases/download/v1.5.0/earthranger_client-1.5.0-py3-none-any.whl
     # via -r requirements.in
 environs==9.5.0
     # via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,6 +241,7 @@ def mock_erclient_class(
         patch_report_reponse,
         post_report_attachment_response,
         post_camera_trap_report_response,
+        post_message_response,
         er_client_close_response
 ):
     mocked_erclient_class = mocker.MagicMock()
@@ -259,6 +260,9 @@ def mock_erclient_class(
     )
     erclient_mock.post_camera_trap_report.return_value = async_return(
         post_camera_trap_report_response
+    )
+    erclient_mock.post_message.return_value = async_return(
+        post_message_response
     )
     erclient_mock.close.return_value = async_return(
         er_client_close_response
@@ -431,6 +435,39 @@ def post_report_attachment_response():
 @pytest.fixture
 def post_camera_trap_report_response():
     return {}
+
+
+@pytest.fixture
+def post_message_response():
+    return {
+        "id": "da783214-0d79-4d8c-ba6c-687688e3f6e7",
+        "sender": {
+            "content_type": "observations.subject",
+            "id": "d2bd0ac8-080d-4be9-a8c2-2250623e6782",
+            "name": "gundi2",
+            "subject_type": "unassigned",
+            "subject_subtype": "mm-inreach-test",
+            "common_name": None,
+            "additional": {},
+            "created_at": "2025-06-05T07:05:12.817899-07:00",
+            "updated_at": "2025-06-05T07:05:12.817926-07:00",
+            "is_active": True,
+            "user": None,
+            "tracks_available": False,
+            "image_url": "/static/pin-black.svg"
+        },
+        "receiver": None,
+        "device": "443724d6-043f-4014-bea6-4d80a38469c8",
+        "message_type": "inbox",
+        "text": "Assistance needed, please respond.",
+        "status": "received",
+        "device_location": {
+            "latitude": -51.688246,
+            "longitude": -72.704459
+        },
+        "message_time": "2025-06-05T04:07:37.401000-07:00",
+        "read": False
+    }
 
 
 @pytest.fixture
@@ -1133,6 +1170,40 @@ def attachment_v2_as_request(mocker):
             },
             "messageId": "11937923011474847",
             "message_id": "11937923011474847",
+            "orderingKey": "",
+            "publishTime": f"{publish_time}",
+            "publish_time": f"{publish_time}"
+        },
+        'subscription': 'projects/MY-PROJECT/subscriptions/MY-SUB'
+    }
+    mock_request.data = json.dumps(json_data)
+    mock_request.get_json.return_value = json_data
+    return mock_request
+
+
+@pytest.fixture
+def text_message_as_pubsub_request(mocker):
+    mock_request = mocker.MagicMock()
+    mock_request.headers = [("Host", "sandbox-earth-dis-762049ee-0613-466b-99a2-59107eb-jba4og2dyq-uc.a.run.app")]
+    publish_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    json_data = {
+        'message': {
+            'data': 'ewogICAiZXZlbnRfaWQiOiI0OGJkMDczYS04ZTM1LTQzY2YtOTFjMi1jN2I0Yjg3YTI2ZDciLAogICAidGltZXN0YW1wIjoiMjAyNS0wNi0wNSAxMzoyMzo0My45NTIwNTYtMDM6MDAiLAogICAic2NoZW1hX3ZlcnNpb24iOiJ2MSIsCiAgICJwYXlsb2FkIjp7CiAgICAgICJtZXNzYWdlX3R5cGUiOiJpbmJveCIsCiAgICAgICJtYW51ZmFjdHVyZXJfaWQiOiIyMDc1NzUyMjQ0IiwKICAgICAgInRleHQiOiJBc3Npc3RhbmNlIG5lZWRlZCwgcGxlYXNlIHJlc3BvbmQuIiwKICAgICAgIm1lc3NhZ2VfdGltZSI6IjIwMjUtMDYtMDUgMDQ6MDc6MzcuNDAxMDAwLTA3OjAwIiwKICAgICAgImRldmljZV9sb2NhdGlvbiI6ewogICAgICAgICAibG9uIjotNzIuNzA0NDU5LAogICAgICAgICAibGF0IjotNTEuNjg4MjQ2CiAgICAgIH0sCiAgICAgICJhZGRpdGlvbmFsIjp7CiAgICAgICAgICJzdGF0dXMiOnsKICAgICAgICAgICAgImF1dG9ub21vdXMiOjAsCiAgICAgICAgICAgICJsb3dCYXR0ZXJ5IjoxLAogICAgICAgICAgICAiaW50ZXJ2YWxDaGFuZ2UiOjAsCiAgICAgICAgICAgICJyZXNldERldGVjdGVkIjowCiAgICAgICAgIH0KICAgICAgfQogICB9LAogICAiZXZlbnRfdHlwZSI6Ik1lc3NhZ2VUcmFuc2Zvcm1lZEVSIgp9',
+            'attributes': {
+                "gundi_version": "v2",
+                "provider_key": "inreach",
+                "gundi_id": "23ca4b15-18b6-4cf4-9da6-36dd69c6f638",
+                "related_to": "None",
+                "stream_type": "txt",
+                "source_id": "afa0d606-c143-4705-955d-68133645db6d",
+                "external_source_id": "2075752244",
+                "destination_id": "338225f3-91f9-4fe1-b013-353a229ce504",
+                "data_provider_id": "ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+                "annotations": "{}",
+                "tracing_context": "{}"
+            },
+            "messageId": "11937923011474850",
+            "message_id": "11937923011474850",
             "orderingKey": "",
             "publishTime": f"{publish_time}",
             "publish_time": f"{publish_time}"


### PR DESCRIPTION
This pull request introduces support for handling and dispatching text messages within the system, alongside several enhancements and updates to dependencies and tests. The most significant changes include adding a new dispatcher for text messages, updating the event handling logic, and expanding test coverage to include text message processing.

### New Feature: Text Message Support
* Added a new dispatcher class, `ERMessageDispatcher`, to handle text messages, including logic to send messages with manufacturer IDs as query parameters (`core/dispatchers.py`).
* Updated the `dispatcher_cls_by_type` mapping to include `schemas.v2.StreamPrefixEnum.text_message` for the new `ERMessageDispatcher` (`core/dispatchers.py`).
* Introduced a new handler function, `handle_er_message`, to process text message events and dispatch them (`core/event_handlers.py`).
* Updated the `event_schemas` and `event_handlers` dictionaries to include `MessageTransformedER` and its corresponding handler (`core/event_handlers.py`). [[1]](diffhunk://#diff-06cdcd8941ea674d6cbca6d015a646f0bdc8c81c2940eea284f34a5edd9f5e9fL10-R11) [[2]](diffhunk://#diff-06cdcd8941ea674d6cbca6d015a646f0bdc8c81c2940eea284f34a5edd9f5e9fR275-R296)

### Dependency Updates
* Upgraded the `earthranger_client` dependency to version 1.5.0 and `gundi-core` to version 1.11.1 to support the new text message functionality (`requirements.in`).

### Test Enhancements
* Added a new test fixture, `text_message_as_pubsub_request`, to simulate incoming text message events (`tests/conftest.py`).
* Expanded the `mock_erclient_class` to include support for mocking `post_message` responses (`tests/conftest.py`).
* Added a new test case, `test_process_text_message_successfully`, to validate the end-to-end processing of text messages, including schema validation and Redis trace writes (`tests/test_process_observations_v2.py`).

### Documentation Update
* Updated the `README.md` to reflect the expanded list of supported observation types, now including text messages (`README.md`).