### PR TITLE
Trigger Main Workflow on pushes to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Main Workflow
 on:
   push:
     branches:
-      - pipeline-refactor
+      - main
 
 jobs:
   main:


### PR DESCRIPTION
## Summary
- Restores the dev deploy pipeline trigger on `.github/workflows/main.yml` from the leftover feature branch `pipeline-refactor` back to `main`.
- Without this, merges to `main` do not run the `pipeline-dispatcher-zip-main` reusable workflow, so the source zip is not uploaded to GCS and the `er-dispatcher-defaults-dev` secret's `deployment_settings.source_code_path` is not updated.

## Test plan
- [ ] Confirm the YAML diff is just `pipeline-refactor` → `main`.
- [ ] After merge, verify a new run of "Main Workflow" appears in the Actions tab and that a fresh `er-dispatcher-src-main-<sha>.zip` lands in the dev GCS bucket.
- [ ] Verify the `er-dispatcher-defaults-dev` secret's `deployment_settings.source_code_path` points at the new zip filename.