### PR TITLE
Publish delivery-failed event when dead-lettering too-old messages

### DIFF
--- a/.env.yaml.template
+++ b/.env.yaml.template
@@ -17,3 +17,4 @@ MAX_EVENT_AGE_SECONDS: '10'
 BUCKET_NAME: 'cdip-dev-cameratrap'
 CLOUD_STORAGE_TYPE: 'google'
 DISPATCHER_EVENTS_TOPIC: 'dispatcher-events-dev'
+RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS: 10  # bound on the DLQ notification publish

--- a/.env.yaml.template
+++ b/.env.yaml.template
@@ -17,4 +17,4 @@ MAX_EVENT_AGE_SECONDS: '10'
 BUCKET_NAME: 'cdip-dev-cameratrap'
 CLOUD_STORAGE_TYPE: 'google'
 DISPATCHER_EVENTS_TOPIC: 'dispatcher-events-dev'
-RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS: 10  # bound on the DLQ notification publish
+RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS: '10'  # bound on the DLQ notification publish

--- a/core/services.py
+++ b/core/services.py
@@ -4,12 +4,17 @@ import aiohttp
 from datetime import datetime, timezone, timedelta
 from gcloud.aio import pubsub
 from gundi_core.schemas.v2 import StreamPrefixEnum
+from gundi_core import events as system_events
+from gundi_core.events import UpdateErrorDetails, DeliveryErrorDetails
+from gundi_core.schemas import v2 as gundi_schemas_v2
 from opentelemetry.trace import SpanKind
 from core import dispatchers
 from core.utils import (
     extract_fields_from_message,
     get_inbound_integration_detail,
     get_outbound_config_detail,
+    is_null,
+    publish_event,
     ExtraKeys,
 )
 from .errors import DispatcherException, ReferenceDataError
@@ -136,6 +141,62 @@ async def send_observation_to_dead_letter_topic(transformed_observation, attribu
         current_span.set_attribute("is_sent_to_dead_letter_queue", True)
         current_span.add_event(
             name="routing_service.observation_sent_to_dead_letter_queue"
+        )
+
+
+async def publish_retries_exhausted_event(attributes: dict):
+    # Notify the portal that we gave up on this message so it's recorded as an
+    # ERROR in the activity log. Intermediate retriable failures are recorded
+    # as warnings, so without this event a message that never delivers would
+    # be dead-lettered silently.
+    gundi_id = attributes.get("gundi_id")
+    destination_id = attributes.get("destination_id")
+    if not gundi_id or not destination_id:
+        logger.warning(
+            "Cannot publish retries-exhausted event without gundi_id and destination_id.",
+            extra={"attributes": attributes},
+        )
+        return
+    data_provider_id = attributes.get("data_provider_id")
+    related_to = attributes.get("related_to")
+    related_to = None if is_null(related_to) else related_to
+    error_msg = (
+        f"Delivery retries exhausted (message older than {settings.MAX_EVENT_AGE_SECONDS} seconds). "
+        "Message sent to dead-letter queue."
+    )
+    if attributes.get("stream_type") == StreamPrefixEnum.event_update.value:
+        event = system_events.ObservationUpdateFailed(
+            payload=UpdateErrorDetails(
+                error=error_msg,
+                observation=gundi_schemas_v2.UpdatedObservation(
+                    gundi_id=gundi_id,
+                    related_to=related_to,
+                    data_provider_id=data_provider_id,
+                    destination_id=destination_id,
+                    updated_at=datetime.now(timezone.utc),
+                ),
+            )
+        )
+    else:
+        event = system_events.ObservationDeliveryFailed(
+            payload=DeliveryErrorDetails(
+                error=error_msg,
+                observation=gundi_schemas_v2.DispatchedObservation(
+                    gundi_id=gundi_id,
+                    related_to=related_to,
+                    external_id=None,
+                    data_provider_id=data_provider_id,
+                    destination_id=destination_id,
+                    delivered_at=datetime.now(timezone.utc),
+                ),
+            )
+        )
+    try:
+        await publish_event(event=event, topic_name=settings.DISPATCHER_EVENTS_TOPIC)
+    except Exception as e:
+        logger.exception(
+            f"Error publishing retries-exhausted event for gundi_id {gundi_id}: {e}. "
+            "The message was still sent to the dead-letter topic."
         )
 
 
@@ -328,6 +389,8 @@ async def process_request(request):
             logger.warning(f"Event is too old (timestamp = {timestamp}) and will be sent to dead-letter.")
             current_span.set_attribute("is_too_old", True)
             await send_observation_to_dead_letter_topic(transformed_observation, attributes)
+            if attributes.get("gundi_version", "v1") == "v2":
+                await publish_retries_exhausted_event(attributes)
             return  # Skip the event
         # Process the event according to the gundi version
         if attributes.get("gundi_version", "v1") == "v2":

--- a/core/services.py
+++ b/core/services.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import aiohttp
@@ -192,7 +193,15 @@ async def publish_retries_exhausted_event(attributes: dict):
                     ),
                 )
             )
-        await publish_event(event=event, topic_name=settings.DISPATCHER_EVENTS_TOPIC)
+        # Bound the total publish time: publish_event retries with backoff
+        # (worst case ~65s), which could exceed the function timeout and cause
+        # the platform to kill us AFTER the DLQ send but BEFORE the ack -
+        # redelivering and dead-lettering the same message repeatedly. A
+        # timeout here lands in the except below and the message is acked.
+        await asyncio.wait_for(
+            publish_event(event=event, topic_name=settings.DISPATCHER_EVENTS_TOPIC),
+            timeout=settings.RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS,
+        )
     except Exception as e:
         logger.exception(
             f"Error publishing retries-exhausted event for gundi_id {gundi_id}: {e}. "

--- a/core/services.py
+++ b/core/services.py
@@ -164,34 +164,34 @@ async def publish_retries_exhausted_event(attributes: dict):
         f"Delivery retries exhausted (message older than {settings.MAX_EVENT_AGE_SECONDS} seconds). "
         "Message sent to dead-letter queue."
     )
-    if attributes.get("stream_type") == StreamPrefixEnum.event_update.value:
-        event = system_events.ObservationUpdateFailed(
-            payload=UpdateErrorDetails(
-                error=error_msg,
-                observation=gundi_schemas_v2.UpdatedObservation(
-                    gundi_id=gundi_id,
-                    related_to=related_to,
-                    data_provider_id=data_provider_id,
-                    destination_id=destination_id,
-                    updated_at=datetime.now(timezone.utc),
-                ),
-            )
-        )
-    else:
-        event = system_events.ObservationDeliveryFailed(
-            payload=DeliveryErrorDetails(
-                error=error_msg,
-                observation=gundi_schemas_v2.DispatchedObservation(
-                    gundi_id=gundi_id,
-                    related_to=related_to,
-                    external_id=None,
-                    data_provider_id=data_provider_id,
-                    destination_id=destination_id,
-                    delivered_at=datetime.now(timezone.utc),
-                ),
-            )
-        )
     try:
+        if attributes.get("stream_type") == StreamPrefixEnum.event_update.value:
+            event = system_events.ObservationUpdateFailed(
+                payload=UpdateErrorDetails(
+                    error=error_msg,
+                    observation=gundi_schemas_v2.UpdatedObservation(
+                        gundi_id=gundi_id,
+                        related_to=related_to,
+                        data_provider_id=data_provider_id,
+                        destination_id=destination_id,
+                        updated_at=datetime.now(timezone.utc),
+                    ),
+                )
+            )
+        else:
+            event = system_events.ObservationDeliveryFailed(
+                payload=DeliveryErrorDetails(
+                    error=error_msg,
+                    observation=gundi_schemas_v2.DispatchedObservation(
+                        gundi_id=gundi_id,
+                        related_to=related_to,
+                        external_id=None,
+                        data_provider_id=data_provider_id,
+                        destination_id=destination_id,
+                        delivered_at=datetime.now(timezone.utc),
+                    ),
+                )
+            )
         await publish_event(event=event, topic_name=settings.DISPATCHER_EVENTS_TOPIC)
     except Exception as e:
         logger.exception(

--- a/core/settings.py
+++ b/core/settings.py
@@ -61,3 +61,7 @@ ATTACHMENTS_DEAD_LETTER_TOPIC = env.str("ATTACHMENTS_DEAD_LETTER_TOPIC", "attach
 TEXT_MESSAGES_DEAD_LETTER_TOPIC = env.str("TEXT_MESSAGES_DEAD_LETTER_TOPIC", "text-messages-dead-letter")
 DISPATCHER_EVENTS_TOPIC = env.str("DISPATCHER_EVENTS_TOPIC", "dispatcher-events-dev")
 MAX_EVENT_AGE_SECONDS = env.int("MAX_EVENT_AGE_SECONDS", 86400)  # 24hrs
+# Hard bound for publishing the retries-exhausted notification after a DLQ
+# send. publish_event retries with backoff (worst case ~65s), which could
+# outlive the function timeout and un-ack an already-dead-lettered message.
+RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS = env.int("RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS", 10)

--- a/docs/superpowers/plans/2026-07-05-transient-er-delivery-errors.md
+++ b/docs/superpowers/plans/2026-07-05-transient-er-delivery-errors.md
@@ -1,0 +1,882 @@
+# Transient ER Delivery Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop transient EarthRanger delivery failures (503/429/timeouts that succeed on retry) from marking Gundi connections unhealthy, while keeping real alarms: sustained outages and retries-exhausted messages.
+
+**Architecture:** Three independent changes. (1) The portal's dispatcher-events consumer classifies retriable ER failures as WARNING instead of ERROR, generalizing an existing 409 special case. (2) The health calculator gains a high-threshold WARNING-volume check so a hard-down ER site still goes unhealthy. (3) The ER dispatcher publishes a final ERROR-level failure event when it dead-letters a message whose retries are exhausted (older than 24h).
+
+**Tech Stack:** Django + Celery + pytest (`cdip` repo), functions-framework + pytest-asyncio (`gundi-dispatcher-er` repo), gundi-core event schemas, erclient.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-transient-er-delivery-errors-design.md` (in `gundi-dispatcher-er`)
+
+## Global Constraints
+
+- Two repos: Tasks 1–4 in `/Users/chrisdo/padas/cdip` (working dir `/Users/chrisdo/padas/cdip/cdip_admin`), Task 5 in `/Users/chrisdo/padas/gundi-dispatcher-er`.
+- `cdip` work happens on branch `feature/transient-er-delivery-alarms` created from up-to-date `main` (run `git fetch origin && git checkout -b feature/transient-er-delivery-alarms origin/main` in `/Users/chrisdo/padas/cdip` before Task 1). `gundi-dispatcher-er` work continues on the existing `spec/transient-er-delivery-errors` branch.
+- Retriable status codes are exactly `{409, 429, 502, 503, 504}`. Plain 500 stays ERROR (deliberate — see spec).
+- The ER integration type slug is `earth_ranger` (verified in `cdip_admin/conftest.py:390`).
+- New health-check setting name: `retriable_error_count_threshold`, default `30`.
+- New status details string (verbatim): `Sustained delivery errors - destination may be down or overloaded`
+- cdip tests run from `/Users/chrisdo/padas/cdip/cdip_admin` with plain `pytest` (pytest.ini sets `DJANGO_SETTINGS_MODULE=cdip_admin.local_settings`, `--reuse-db`). Requires the local dev database used by the existing suite.
+- Existing behavior that must not change: v1 legacy events stay ERROR; non-ER destinations stay ERROR; 400/401/403/404/500 stay ERROR.
+
+---
+
+### Task 1: Portal — retriable-error classifier + delivery-failed handler
+
+**Files:**
+- Modify: `/Users/chrisdo/padas/cdip/cdip_admin/event_consumers/dispatcher_events_consumer.py` (helper near top after imports; classification at lines ~181-185)
+- Test: `/Users/chrisdo/padas/cdip/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py`
+
+**Interfaces:**
+- Consumes: existing `Integration` model import (already imported in this module — used by `handle_dispatcher_log_event`), `ActivityLog.LogLevels`.
+- Produces: `is_retriable_er_error(error: str | None, server_response_status: int | None, destination: Integration | None) -> bool`, plus module constants `RETRIABLE_ER_STATUS_CODES: set[int]` and `TRANSIENT_ER_ERROR_MARKERS: tuple[str, ...]`. Task 2 reuses all three.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `event_consumers/tests/test_dispatcher_events_consumer.py`. Add `from unittest.mock import MagicMock` to the imports at the top of the file (`json`, `pytest`, `ActivityLog`, `process_event`, etc. are already imported there). Add a module-level helper and tests at the end of the file:
+
+```python
+def _make_er_delivery_failed_message(trace, destination, error, server_response_status=None,
+                                     server_response_body=""):
+    message = MagicMock()
+    event_dict = {
+        "event_id": "605535df-1b9b-412b-9fd5-e29b09582999",
+        "timestamp": "2023-07-11 18:19:19.215459+00:00",
+        "schema_version": "v2",
+        "event_type": "ObservationDeliveryFailed",
+        "payload": {
+            "error": error,
+            "error_traceback": "Traceback (most recent call last): ...",
+            "server_response_status": server_response_status,
+            "server_response_body": server_response_body,
+            "observation": {
+                "gundi_id": str(trace.object_id),
+                "related_to": None,
+                "data_provider_id": str(trace.data_provider.id),
+                "destination_id": str(destination.id),
+                "delivered_at": "2025-01-23 16:54:19.215015+00:00",
+            },
+        }
+    }
+    message.data = json.dumps(event_dict).encode("utf-8")
+    return message
+
+
+@pytest.mark.parametrize("server_response_status", [409, 429, 502, 503, 504])
+def test_retriable_status_delivery_errors_are_logged_as_warnings(
+        lotek_observation_trace, integrations_list_er, server_response_status
+):
+    message = _make_er_delivery_failed_message(
+        trace=lotek_observation_trace,
+        destination=integrations_list_er[0],
+        error=f"ERClientException: ER error ON POST https://fake-site.pamdas.org/api/v1.0/sensors/",
+        server_response_status=server_response_status,
+        server_response_body='{"status": {"message": "err"}}',
+    )
+    process_event(message)
+    activity_log = ActivityLog.objects.filter(
+        integration_id=str(lotek_observation_trace.data_provider.id)
+    ).first()
+    assert activity_log
+    assert activity_log.log_level == ActivityLog.LogLevels.WARNING
+    assert activity_log.value == "observation_delivery_failed"
+
+
+@pytest.mark.parametrize("error", [
+    # erclient wraps httpx.RequestError (timeouts, connection errors) into an
+    # ERClientException with no status code and the "Request to ER failed" prefix.
+    "ERClientException: Request to ER failed: Connection timeout to host https://fake-site.pamdas.org",
+    "ERClientServiceUnreachable: ER Service Unavailable ON POST https://fake-site.pamdas.org/api/v1.0/sensors/",
+    "ERClientRateLimitExceeded: ER Too Many Requests ON POST https://fake-site.pamdas.org/api/v1.0/sensors/",
+    "ClientConnectorError: Cannot connect to host fake-site.pamdas.org:443 ssl:default",
+    "ServerTimeoutError: Timeout on reading data from socket",
+    "ServerDisconnectedError: Server disconnected",
+    "ClientOSError: [Errno 104] Connection reset by peer",
+    "ConnectionResetError: [Errno 104] Connection reset by peer",
+    "TimeoutError: Request timed out",
+])
+def test_transient_errors_without_status_are_logged_as_warnings(
+        lotek_observation_trace, integrations_list_er, error
+):
+    message = _make_er_delivery_failed_message(
+        trace=lotek_observation_trace,
+        destination=integrations_list_er[0],
+        error=error,
+        server_response_status=None,
+    )
+    process_event(message)
+    activity_log = ActivityLog.objects.filter(
+        integration_id=str(lotek_observation_trace.data_provider.id)
+    ).first()
+    assert activity_log
+    assert activity_log.log_level == ActivityLog.LogLevels.WARNING
+
+
+def test_retries_exhausted_failures_are_logged_as_errors(
+        lotek_observation_trace, integrations_list_er
+):
+    # The dispatcher publishes this event when it dead-letters a message whose
+    # retries are exhausted (Task 5). It must land as ERROR: "we gave up" is
+    # the real alarm.
+    message = _make_er_delivery_failed_message(
+        trace=lotek_observation_trace,
+        destination=integrations_list_er[0],
+        error="Delivery retries exhausted (message older than 86400 seconds). Message sent to dead-letter queue.",
+        server_response_status=None,
+    )
+    process_event(message)
+    activity_log = ActivityLog.objects.filter(
+        integration_id=str(lotek_observation_trace.data_provider.id)
+    ).first()
+    assert activity_log
+    assert activity_log.log_level == ActivityLog.LogLevels.ERROR
+
+
+@pytest.mark.parametrize("server_response_status,error", [
+    (500, "ERClientInternalError: ER Internal Server Error ON POST https://fake-site.pamdas.org/api/v1.0/sensors/"),
+    (401, "ERClientBadCredentials: ER Unauthorized ON POST https://fake-site.pamdas.org/api/v1.0/sensors/"),
+    (400, "ERClientBadRequest: ER Bad Request ON POST https://fake-site.pamdas.org/api/v1.0/sensors/"),
+    (404, "ERClientNotFound: ER Not Found ON POST https://fake-site.pamdas.org/api/v1.0/sensors/"),
+])
+def test_non_retriable_delivery_errors_are_logged_as_errors(
+        lotek_observation_trace, integrations_list_er, server_response_status, error
+):
+    message = _make_er_delivery_failed_message(
+        trace=lotek_observation_trace,
+        destination=integrations_list_er[0],
+        error=error,
+        server_response_status=server_response_status,
+    )
+    process_event(message)
+    activity_log = ActivityLog.objects.filter(
+        integration_id=str(lotek_observation_trace.data_provider.id)
+    ).first()
+    assert activity_log
+    assert activity_log.log_level == ActivityLog.LogLevels.ERROR
+
+
+def test_retriable_errors_from_non_er_destinations_stay_errors(
+        trap_tagger_to_movebank_observation_trace, destination_movebank
+):
+    # Classification is scoped to EarthRanger destinations only.
+    message = _make_er_delivery_failed_message(
+        trace=trap_tagger_to_movebank_observation_trace,
+        destination=destination_movebank,
+        error="Exception: Service Unavailable",
+        server_response_status=503,
+    )
+    process_event(message)
+    activity_log = ActivityLog.objects.filter(
+        integration_id=str(trap_tagger_to_movebank_observation_trace.data_provider.id)
+    ).first()
+    assert activity_log
+    assert activity_log.log_level == ActivityLog.LogLevels.ERROR
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest event_consumers/tests/test_dispatcher_events_consumer.py -v -k "retriable or transient or retries_exhausted"
+```
+Expected: the 409 parametrized case PASSES (existing behavior — its error string contains "pamdas.org"); the 429/502/503/504 cases and all `test_transient_errors_without_status...` cases FAIL with `assert 'error' == 'warning'`-style assertion errors; the non-retriable, non-ER, and retries-exhausted tests PASS (current behavior is already ERROR). This confirms the tests measure the right thing.
+
+- [ ] **Step 3: Implement the classifier and use it in the delivery-failed handler**
+
+In `event_consumers/dispatcher_events_consumer.py`, add after the imports/`data_type_str_map` section near the top:
+
+```python
+# HTTP statuses from EarthRanger that indicate a transient condition. The
+# dispatcher re-raises on failure so PubSub retries the message; these
+# failures usually resolve on retry and must not count toward the
+# unhealthy threshold in the health calculator.
+RETRIABLE_ER_STATUS_CODES = {409, 429, 502, 503, 504}
+
+# Markers of transient failures that carry no HTTP status code. The dispatcher
+# formats errors as f"{type(e).__name__}: {e}", so exception class names appear
+# in the error string. "Request to ER failed" is the message erclient uses when
+# wrapping network errors and timeouts (httpx.RequestError). "Will retry later"
+# is the dispatcher's message when an event update arrives before its parent
+# event was delivered.
+TRANSIENT_ER_ERROR_MARKERS = (
+    "Request to ER failed",
+    "ERClientServiceUnreachable",
+    "ERClientRateLimitExceeded",
+    "ClientConnectorError",
+    "ServerTimeoutError",
+    "ServerDisconnectedError",
+    "ClientOSError",
+    "ConnectionResetError",
+    "TimeoutError",
+    "Will retry later",
+)
+
+
+def is_retriable_er_error(error, server_response_status, destination):
+    # Retriable failures against EarthRanger destinations are logged as WARNING
+    # so temporary outages don't mark the connection unhealthy. Sustained
+    # volumes of these warnings are caught by a separate threshold in
+    # calculate_integration_status.
+    if not destination or destination.type.value != "earth_ranger":
+        return False
+    if server_response_status in RETRIABLE_ER_STATUS_CODES:
+        return True
+    if not server_response_status and error:
+        return any(marker in error for marker in TRANSIENT_ER_ERROR_MARKERS)
+    return False
+```
+
+In `handle_observation_delivery_failed_event`, replace:
+
+```python
+    # Flag the error as a warning if ER returns a 409 conflict error. Those are retried.
+    if "pamdas.org" in event.payload.error and event.payload.server_response_status == 409:
+        level = ActivityLog.LogLevels.WARNING
+    else:
+        level = ActivityLog.LogLevels.ERROR
+```
+
+with:
+
+```python
+    destination = Integration.objects.filter(id=str(observation.destination_id)).first()
+    if is_retriable_er_error(
+        error=event.payload.error,
+        server_response_status=event.payload.server_response_status,
+        destination=destination,
+    ):
+        level = ActivityLog.LogLevels.WARNING
+    else:
+        level = ActivityLog.LogLevels.ERROR
+```
+
+Note: v1 legacy events keep ERROR automatically — their synthesized error text ("Delivery Failed at the Dispatcher. Please update this dispatcher...") matches no marker and has no status code.
+
+- [ ] **Step 4: Run the consumer test module to verify everything passes**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest event_consumers/tests/test_dispatcher_events_consumer.py -v
+```
+Expected: ALL PASS, including the pre-existing `test_409_delivery_errors_are_logged_as_warnings` (its fixture is an ER destination with status 409 → still WARNING) and `test_process_observation_delivery_failed_event` (its v2 fixture is a 400 `ERClientBadRequest` → still ERROR).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/chrisdo/padas/cdip && git add cdip_admin/event_consumers/dispatcher_events_consumer.py cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py && git commit -m "Log retriable ER delivery failures as warnings
+
+Generalizes the ER-409 special case: 409/429/502/503/504 responses and
+status-less network/timeout failures against EarthRanger destinations are
+transient and retried by PubSub, so they are recorded as WARNING instead
+of ERROR and no longer trip the unhealthy threshold."
+```
+
+---
+
+### Task 2: Portal — classify update-failed events with the same helper
+
+**Files:**
+- Modify: `/Users/chrisdo/padas/cdip/cdip_admin/event_consumers/dispatcher_events_consumer.py` (`handle_observation_update_failed_event`, ActivityLog creation at lines ~292-301)
+- Test: `/Users/chrisdo/padas/cdip/cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py` (modify `test_process_observation_update_failed_event`)
+
+**Interfaces:**
+- Consumes: `is_retriable_er_error(error, server_response_status, destination)` from Task 1 (same module).
+- Produces: nothing new — update-failed activity logs now carry `log_level=WARNING` when retriable. Task 4 counts these via `value="observation_update_failed"`.
+
+- [ ] **Step 1: Update the existing test to expect WARNING for the v2 case**
+
+The existing v2 fixture `trap_tagger_observation_update_failed_schema_v2_event` (conftest.py:2755) has error `"Event ... wasn't delivered yet. Will retry later."`, `server_response_status: None`, and an ER destination — under the new classification it becomes WARNING. The v1 case stays ERROR. In `test_process_observation_update_failed_event`, replace:
+
+```python
+    assert activity_log.log_level == ActivityLog.LogLevels.ERROR
+```
+
+with:
+
+```python
+    if schema_version == "v1":
+        # v1 events carry no status/error detail; current behavior is preserved
+        assert activity_log.log_level == ActivityLog.LogLevels.ERROR
+    else:
+        # The v2 fixture is a "Will retry later" reference-data wait — retriable
+        assert activity_log.log_level == ActivityLog.LogLevels.WARNING
+```
+
+Also add a new test at the end of the file for a non-retriable update failure staying ERROR:
+
+```python
+def test_non_retriable_update_failures_are_logged_as_errors(
+        trap_tagger_event_update_trace, integrations_list_er
+):
+    message = MagicMock()
+    event_dict = {
+        "event_id": "605535df-1b9b-412b-9fd5-e29b09582999",
+        "timestamp": "2023-07-11 18:19:19.215459+00:00",
+        "schema_version": "v2",
+        "event_type": "ObservationUpdateFailed",
+        "payload": {
+            "error": "ERClientBadRequest: ER Bad Request ON PATCH https://fake-site.pamdas.org/api/v1.0/activity/event/1234",
+            "error_traceback": "",
+            "server_response_status": 400,
+            "server_response_body": '{"status": {"code": 400}}',
+            "observation": {
+                "gundi_id": str(trap_tagger_event_update_trace.object_id),
+                "related_to": None,
+                "data_provider_id": str(trap_tagger_event_update_trace.data_provider.id),
+                "destination_id": str(integrations_list_er[0].id),
+                "updated_at": "2024-07-25 12:25:44.442696+00:00",
+            },
+        },
+    }
+    message.data = json.dumps(event_dict).encode("utf-8")
+    process_event(message)
+    activity_log = ActivityLog.objects.filter(
+        integration_id=str(trap_tagger_event_update_trace.data_provider.id)
+    ).first()
+    assert activity_log
+    assert activity_log.log_level == ActivityLog.LogLevels.ERROR
+    assert activity_log.value == "observation_update_failed"
+```
+
+- [ ] **Step 2: Run to verify the updated test fails**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest event_consumers/tests/test_dispatcher_events_consumer.py -v -k "update_failed"
+```
+Expected: `test_process_observation_update_failed_event[schema_v2]` FAILS (log is still ERROR, test now expects WARNING); `[schema_v1]` and the new non-retriable test PASS.
+
+- [ ] **Step 3: Apply the classifier in the update-failed handler**
+
+In `handle_observation_update_failed_event`, replace the unconditional ERROR:
+
+```python
+    ActivityLog.objects.create(
+        log_level=ActivityLog.LogLevels.ERROR,
+```
+
+with:
+
+```python
+    destination = Integration.objects.filter(id=destination_id).first()
+    if is_retriable_er_error(
+        error=event_data.error,
+        server_response_status=getattr(event_data, "server_response_status", None),
+        destination=destination,
+    ):
+        level = ActivityLog.LogLevels.WARNING
+    else:
+        level = ActivityLog.LogLevels.ERROR
+    ActivityLog.objects.create(
+        log_level=level,
+```
+
+(`destination_id` is already a local variable in this handler. `getattr` guards the v1-built payload, which may omit the field depending on gundi-core defaults.)
+
+- [ ] **Step 4: Run the full consumer test module**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest event_consumers/tests/test_dispatcher_events_consumer.py -v
+```
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/chrisdo/padas/cdip && git add cdip_admin/event_consumers/dispatcher_events_consumer.py cdip_admin/event_consumers/tests/test_dispatcher_events_consumer.py && git commit -m "Log retriable ER update failures as warnings
+
+Applies the same retriable-error classification to ObservationUpdateFailed
+events, covering 'Will retry later' reference-data waits (event updates
+arriving before their parent event) and transient ER responses."
+```
+
+---
+
+### Task 3: Portal — `retriable_error_count_threshold` setting + migration
+
+**Files:**
+- Modify: `/Users/chrisdo/padas/cdip/cdip_admin/integrations/models/v2/models.py` (`HealthCheckSettings`, lines ~593-608)
+- Create: `/Users/chrisdo/padas/cdip/cdip_admin/integrations/migrations/0116_healthchecksettings_retriable_error_count_threshold.py` (generated)
+- Test: `/Users/chrisdo/padas/cdip/cdip_admin/integrations/tests/test_calc_integration_status.py`
+
+**Interfaces:**
+- Consumes: existing `HealthCheckSettings` model (fields `error_count_threshold`, `time_window_minutes`).
+- Produces: `HealthCheckSettings.retriable_error_count_threshold: PositiveIntegerField(default=30)`. Task 4 reads it in `calculate_integration_status`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `integrations/tests/test_calc_integration_status.py`:
+
+```python
+def test_health_check_settings_have_retriable_error_threshold(provider_lotek_panthera):
+    settings = provider_lotek_panthera.health_check_settings
+    assert settings.retriable_error_count_threshold == 30
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest integrations/tests/test_calc_integration_status.py::test_health_check_settings_have_retriable_error_threshold -v
+```
+Expected: FAIL with `AttributeError: 'HealthCheckSettings' object has no attribute 'retriable_error_count_threshold'`.
+
+- [ ] **Step 3: Add the field and generate the migration**
+
+In `integrations/models/v2/models.py`, inside `HealthCheckSettings` after `time_window_minutes`:
+
+```python
+    retriable_error_count_threshold = models.PositiveIntegerField(
+        default=30,
+        help_text=(
+            "Number of retriable (warning-level) delivery failures within the time window "
+            "before the integration is marked unhealthy. Retriable failures are transient "
+            "destination errors that PubSub retries; a sustained volume indicates an outage."
+        ),
+    )
+```
+
+Generate the migration:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && python manage.py makemigrations integrations
+```
+Expected output: `integrations/migrations/0116_healthchecksettings_retriable_error_count_threshold.py` with a single `AddField` operation. (If `manage.py` needs the settings module explicitly, prefix with `DJANGO_SETTINGS_MODULE=cdip_admin.local_settings`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest integrations/tests/test_calc_integration_status.py::test_health_check_settings_have_retriable_error_threshold -v
+```
+Expected: PASS (pytest applies the new migration to the test DB; if `--reuse-db` skips it, run once with `pytest --create-db` for this module).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/chrisdo/padas/cdip && git add cdip_admin/integrations/models/v2/models.py cdip_admin/integrations/migrations/ cdip_admin/integrations/tests/test_calc_integration_status.py && git commit -m "Add retriable_error_count_threshold to health check settings"
+```
+
+---
+
+### Task 4: Portal — WARNING-volume safety net in the health calculator
+
+**Files:**
+- Modify: `/Users/chrisdo/padas/cdip/cdip_admin/integrations/models/v2/services.py` (`calculate_integration_status`, lines ~102-119)
+- Test: `/Users/chrisdo/padas/cdip/cdip_admin/integrations/tests/test_calc_integration_status.py`
+
+**Interfaces:**
+- Consumes: `HealthCheckSettings.retriable_error_count_threshold` (Task 3); WARNING logs with `value in ("observation_delivery_failed", "observation_update_failed")` produced by Tasks 1–2.
+- Produces: new UNHEALTHY branch with `status_details = "Sustained delivery errors - destination may be down or overloaded"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `integrations/tests/test_calc_integration_status.py`. Add `from activity_log.models import ActivityLog` to the imports, then:
+
+```python
+def _make_retriable_delivery_warning_logs(integration, count, value="observation_delivery_failed"):
+    return [
+        ActivityLog.objects.create(
+            log_level=ActivityLog.LogLevels.WARNING,
+            log_type=ActivityLog.LogTypes.EVENT,
+            origin=ActivityLog.Origin.DISPATCHER,
+            integration=integration,
+            value=value,
+            title="Error Delivering Observation to 'https://fake-site.pamdas.org'",
+            details={"server_response_status": 503},
+            is_reversible=False,
+        )
+        for _ in range(count)
+    ]
+
+
+def test_sustained_retriable_delivery_errors_mark_integration_unhealthy(provider_lotek_panthera):
+    provider_lotek_panthera.health_check_settings.retriable_error_count_threshold = 3
+    provider_lotek_panthera.health_check_settings.save()
+    _make_retriable_delivery_warning_logs(provider_lotek_panthera, count=3)
+
+    calculate_integration_status(integration_id=provider_lotek_panthera.id)
+
+    provider_lotek_panthera.status.refresh_from_db()
+    assert provider_lotek_panthera.status.status == IntegrationStatus.Status.UNHEALTHY
+    assert provider_lotek_panthera.status.status_details == (
+        "Sustained delivery errors - destination may be down or overloaded"
+    )
+
+
+def test_few_retriable_delivery_errors_keep_integration_healthy(provider_lotek_panthera):
+    # Below the threshold (default 30), retriable warnings must not alarm
+    _make_retriable_delivery_warning_logs(provider_lotek_panthera, count=5)
+
+    calculate_integration_status(integration_id=provider_lotek_panthera.id)
+
+    provider_lotek_panthera.status.refresh_from_db()
+    assert provider_lotek_panthera.status.status == IntegrationStatus.Status.HEALTHY
+
+
+def test_unrelated_warnings_do_not_count_toward_sustained_errors(provider_lotek_panthera):
+    provider_lotek_panthera.health_check_settings.retriable_error_count_threshold = 3
+    provider_lotek_panthera.health_check_settings.save()
+    _make_retriable_delivery_warning_logs(provider_lotek_panthera, count=3, value="custom_dispatcher_log")
+
+    calculate_integration_status(integration_id=provider_lotek_panthera.id)
+
+    provider_lotek_panthera.status.refresh_from_db()
+    assert provider_lotek_panthera.status.status == IntegrationStatus.Status.HEALTHY
+
+
+def test_error_threshold_takes_precedence_over_warning_threshold(
+        provider_lotek_panthera,
+        pull_observations_action_started_activity_log,
+        pull_observations_action_failed_activity_log,
+        pull_observations_action_failed_activity_log_2,
+        pull_observations_action_failed_activity_log_3
+):
+    # When both thresholds are crossed, the ERROR branch runs first and its
+    # status_details wins (the elif chain in calculate_integration_status).
+    provider_lotek_panthera.health_check_settings.retriable_error_count_threshold = 3
+    provider_lotek_panthera.health_check_settings.save()
+    _make_retriable_delivery_warning_logs(provider_lotek_panthera, count=3)
+
+    calculate_integration_status(integration_id=provider_lotek_panthera.id)
+
+    provider_lotek_panthera.status.refresh_from_db()
+    assert provider_lotek_panthera.status.status == IntegrationStatus.Status.UNHEALTHY
+    assert provider_lotek_panthera.status.status_details != (
+        "Sustained delivery errors - destination may be down or overloaded"
+    )
+
+
+def test_retriable_update_failures_count_toward_sustained_errors(provider_lotek_panthera):
+    provider_lotek_panthera.health_check_settings.retriable_error_count_threshold = 4
+    provider_lotek_panthera.health_check_settings.save()
+    _make_retriable_delivery_warning_logs(provider_lotek_panthera, count=2)
+    _make_retriable_delivery_warning_logs(provider_lotek_panthera, count=2, value="observation_update_failed")
+
+    calculate_integration_status(integration_id=provider_lotek_panthera.id)
+
+    provider_lotek_panthera.status.refresh_from_db()
+    assert provider_lotek_panthera.status.status == IntegrationStatus.Status.UNHEALTHY
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest integrations/tests/test_calc_integration_status.py -v -k "sustained or unrelated_warnings or retriable_update"
+```
+Expected: `test_sustained_...` and `test_retriable_update_...` FAIL (status stays healthy); the two negative tests PASS.
+
+- [ ] **Step 3: Add the WARNING-volume branch**
+
+In `integrations/models/v2/services.py::calculate_integration_status`, after the existing `elif` for DISPATCHER-origin ERROR logs (the block ending `"Errors were detected while pushing data to the destination"`), add a further `elif`:
+
+```python
+    elif ActivityLog.objects.filter(
+        origin=ActivityLog.Origin.DISPATCHER,
+        integration=integration,
+        log_level=ActivityLog.LogLevels.WARNING,
+        value__in=("observation_delivery_failed", "observation_update_failed"),
+        created_at__gte=time_window
+    ).count() >= healthcheck_settings.retriable_error_count_threshold:
+        # Retriable (transient) delivery failures are logged as warnings and don't
+        # count toward the error threshold above. But a sustained volume of them
+        # means the destination is down or overloaded, which must still alarm.
+        integration_status.status = IntegrationStatus.Status.UNHEALTHY
+        integration_status.status_details = "Sustained delivery errors - destination may be down or overloaded"
+```
+
+- [ ] **Step 4: Run the health-calc test module**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest integrations/tests/test_calc_integration_status.py -v
+```
+Expected: ALL PASS (existing threshold tests unaffected — they use ERROR-level logs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/chrisdo/padas/cdip && git add cdip_admin/integrations/models/v2/services.py cdip_admin/integrations/tests/test_calc_integration_status.py && git commit -m "Mark integrations unhealthy on sustained retriable delivery errors
+
+Retriable ER failures are now warnings and skip the error threshold, so a
+hard-down destination would otherwise never alarm. Count delivery/update
+failure warnings against retriable_error_count_threshold (default 30) in
+the same time window."
+```
+
+---
+
+### Task 5: Dispatcher — publish ERROR event when dead-lettering a too-old v2 message
+
+**Files:**
+- Modify: `/Users/chrisdo/padas/gundi-dispatcher-er/core/services.py` (imports at top; new function after `send_observation_to_dead_letter_topic`; too-old branch in `process_request`, lines ~327-331)
+- Modify: `/Users/chrisdo/padas/gundi-dispatcher-er/tests/conftest.py` (three too-old request fixtures)
+- Test: `/Users/chrisdo/padas/gundi-dispatcher-er/tests/test_dead_lettering.py`
+
+**Interfaces:**
+- Consumes: `publish_event(event, topic_name)` and `is_null(value)` from `core/utils.py`; `system_events.ObservationDeliveryFailed` / `ObservationUpdateFailed`, `DeliveryErrorDetails` / `UpdateErrorDetails` from `gundi_core.events`; `gundi_schemas_v2.DispatchedObservation` / `UpdatedObservation`.
+- Produces: `publish_retries_exhausted_event(attributes: dict) -> None` (async) in `core/services.py`, called from `process_request` for v2 messages only. The portal (Task 1 classifier) records it as ERROR: no status code and no transient marker in the text.
+
+- [ ] **Step 1: Add too-old request fixtures**
+
+In `/Users/chrisdo/padas/gundi-dispatcher-er/tests/conftest.py`, add (near the existing `*_as_pubsub_request` fixtures around line 841; `datetime`, `json`, and `settings` are already imported in this module):
+
+```python
+def _make_request_too_old(request_fixture):
+    # Rewind publish_time so is_too_old() routes the message to the DLQ
+    json_data = request_fixture.get_json.return_value
+    old_publish_time = (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(seconds=settings.MAX_EVENT_AGE_SECONDS + 3600)
+    ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    json_data["message"]["publish_time"] = old_publish_time
+    json_data["message"]["publishTime"] = old_publish_time
+    request_fixture.data = json.dumps(json_data)
+    return request_fixture
+
+
+@pytest.fixture
+def event_v2_as_pubsub_request_too_old(event_v2_as_pubsub_request):
+    return _make_request_too_old(event_v2_as_pubsub_request)
+
+
+@pytest.fixture
+def event_update_v2_as_pubsub_request_too_old(event_update_v2_as_pubsub_request):
+    return _make_request_too_old(event_update_v2_as_pubsub_request)
+
+
+@pytest.fixture
+def position_as_request_too_old(position_as_request):
+    return _make_request_too_old(position_as_request)
+```
+
+(If `from core import settings` is not already among conftest imports, add it.)
+
+- [ ] **Step 2: Write the failing tests**
+
+In `/Users/chrisdo/padas/gundi-dispatcher-er/tests/test_dead_lettering.py`, extend the imports:
+
+```python
+from gundi_core import events as system_events
+from core.services import send_observation_to_dead_letter_topic, process_request
+```
+
+and add:
+
+```python
+@pytest.mark.asyncio
+async def test_too_old_v2_event_publishes_retries_exhausted_error(
+        mocker, mock_pubsub_client, mock_publish_event, event_v2_as_pubsub_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    await process_request(event_v2_as_pubsub_request_too_old)
+
+    # The message was sent to the events DLQ topic
+    publish_calls = [c for c in mock_pubsub_client.PublisherClient.mock_calls if c[0] == "().publish"]
+    assert len(publish_calls) == 1
+    assert publish_calls[0].args[0] == f"projects/{settings.GCP_PROJECT_ID}/topics/{settings.EVENTS_DEAD_LETTER_TOPIC}"
+    # And a retries-exhausted failure event was published for the portal
+    assert mock_publish_event.called
+    call_kwargs = mock_publish_event.call_args.kwargs
+    event = call_kwargs["event"]
+    assert isinstance(event, system_events.ObservationDeliveryFailed)
+    assert "retries exhausted" in event.payload.error.lower()
+    assert event.payload.server_response_status is None
+    assert str(event.payload.observation.gundi_id) == "23ca4b15-18b6-4cf4-9da6-36dd69c6f638"
+    assert call_kwargs["topic_name"] == settings.DISPATCHER_EVENTS_TOPIC
+
+
+@pytest.mark.asyncio
+async def test_too_old_v2_event_update_publishes_update_failed_error(
+        mocker, mock_pubsub_client, mock_publish_event, event_update_v2_as_pubsub_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    await process_request(event_update_v2_as_pubsub_request_too_old)
+
+    assert mock_publish_event.called
+    event = mock_publish_event.call_args.kwargs["event"]
+    assert isinstance(event, system_events.ObservationUpdateFailed)
+    assert "retries exhausted" in event.payload.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_too_old_v1_message_does_not_publish_failure_event(
+        mocker, mock_pubsub_client, mock_publish_event, position_as_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    await process_request(position_as_request_too_old)
+
+    # v1 messages go to the legacy DLQ with no portal event (deprecated path)
+    publish_calls = [c for c in mock_pubsub_client.PublisherClient.mock_calls if c[0] == "().publish"]
+    assert len(publish_calls) == 1
+    assert publish_calls[0].args[0] == f"projects/{settings.GCP_PROJECT_ID}/topics/{settings.LEGACY_DEAD_LETTER_TOPIC}"
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_failure_publishing_retries_exhausted_event_does_not_raise(
+        mocker, mock_pubsub_client, mock_publish_event, event_v2_as_pubsub_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mock_publish_event.side_effect = Exception("PubSub is down")
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    # Must not raise: the DLQ send already succeeded and the message must be acked
+    await process_request(event_v2_as_pubsub_request_too_old)
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/gundi-dispatcher-er && pytest tests/test_dead_lettering.py -v
+```
+Expected: the three new v2/v1 tests FAIL — the first two with `AttributeError: <module 'core.services'> does not have the attribute 'publish_event'` (patch target doesn't exist yet) or `assert mock_publish_event.called`; the existing parametrized DLQ tests PASS.
+
+- [ ] **Step 4: Implement `publish_retries_exhausted_event`**
+
+In `/Users/chrisdo/padas/gundi-dispatcher-er/core/services.py`:
+
+Extend the imports at the top:
+
+```python
+from gundi_core import events as system_events
+from gundi_core.events import UpdateErrorDetails, DeliveryErrorDetails
+from gundi_core.schemas import v2 as gundi_schemas_v2
+from core.utils import (
+    extract_fields_from_message,
+    get_inbound_integration_detail,
+    get_outbound_config_detail,
+    is_null,
+    publish_event,
+    ExtraKeys,
+)
+```
+
+Add after `send_observation_to_dead_letter_topic`:
+
+```python
+async def publish_retries_exhausted_event(attributes: dict):
+    # Notify the portal that we gave up on this message so it's recorded as an
+    # ERROR in the activity log. Intermediate retriable failures are recorded
+    # as warnings, so without this event a message that never delivers would
+    # be dead-lettered silently.
+    gundi_id = attributes.get("gundi_id")
+    destination_id = attributes.get("destination_id")
+    if not gundi_id or not destination_id:
+        logger.warning(
+            "Cannot publish retries-exhausted event without gundi_id and destination_id.",
+            extra={"attributes": attributes},
+        )
+        return
+    data_provider_id = attributes.get("data_provider_id")
+    related_to = attributes.get("related_to")
+    related_to = None if is_null(related_to) else related_to
+    error_msg = (
+        f"Delivery retries exhausted (message older than {settings.MAX_EVENT_AGE_SECONDS} seconds). "
+        "Message sent to dead-letter queue."
+    )
+    if attributes.get("stream_type") == StreamPrefixEnum.event_update.value:
+        event = system_events.ObservationUpdateFailed(
+            payload=UpdateErrorDetails(
+                error=error_msg,
+                observation=gundi_schemas_v2.UpdatedObservation(
+                    gundi_id=gundi_id,
+                    related_to=related_to,
+                    data_provider_id=data_provider_id,
+                    destination_id=destination_id,
+                    updated_at=datetime.now(timezone.utc),
+                ),
+            )
+        )
+    else:
+        event = system_events.ObservationDeliveryFailed(
+            payload=DeliveryErrorDetails(
+                error=error_msg,
+                observation=gundi_schemas_v2.DispatchedObservation(
+                    gundi_id=gundi_id,
+                    related_to=related_to,
+                    external_id=None,
+                    data_provider_id=data_provider_id,
+                    destination_id=destination_id,
+                    delivered_at=datetime.now(timezone.utc),
+                ),
+            )
+        )
+    try:
+        await publish_event(event=event, topic_name=settings.DISPATCHER_EVENTS_TOPIC)
+    except Exception as e:
+        logger.exception(
+            f"Error publishing retries-exhausted event for gundi_id {gundi_id}: {e}. "
+            "The message was still sent to the dead-letter topic."
+        )
+```
+
+In `process_request`, change the too-old branch:
+
+```python
+        if is_too_old(timestamp):
+            logger.warning(f"Event is too old (timestamp = {timestamp}) and will be sent to dead-letter.")
+            current_span.set_attribute("is_too_old", True)
+            await send_observation_to_dead_letter_topic(transformed_observation, attributes)
+            if attributes.get("gundi_version", "v1") == "v2":
+                await publish_retries_exhausted_event(attributes)
+            return  # Skip the event
+```
+
+(`datetime`/`timezone` and `StreamPrefixEnum` are already imported in this module.)
+
+- [ ] **Step 5: Run the dead-lettering tests, then the full suite**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/gundi-dispatcher-er && pytest tests/test_dead_lettering.py -v && pytest
+```
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/chrisdo/padas/gundi-dispatcher-er && git add core/services.py tests/conftest.py tests/test_dead_lettering.py && git commit -m "Publish delivery-failed event when dead-lettering too-old v2 messages
+
+Retriable failures are recorded as warnings in the portal, so a message
+whose retries are exhausted (older than MAX_EVENT_AGE_SECONDS) would be
+dead-lettered silently. Publish an ObservationDeliveryFailed /
+ObservationUpdateFailed with no status code so the portal records one
+ERROR-level activity log at the moment we give up."
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the affected cdip test modules**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/cdip/cdip_admin && pytest event_consumers/ integrations/tests/test_calc_integration_status.py integrations/tests/test_email_alerts.py -v
+```
+Expected: ALL PASS. (`test_email_alerts.py` is included because it exercises statuses produced by `calculate_integration_status`.)
+
+- [ ] **Step 2: Run the full dispatcher suite**
+
+Run:
+```bash
+cd /Users/chrisdo/padas/gundi-dispatcher-er && pytest
+```
+Expected: ALL PASS.
+
+- [ ] **Step 3: Report**
+
+Summarize for the user: branches (`feature/transient-er-delivery-alarms` in cdip, `spec/transient-er-delivery-errors` in gundi-dispatcher-er), commits, and the deploy note from the spec — the portal deploy activates classification + safety net fleet-wide immediately; the dispatcher change ships with the next dispatcher release; thresholds are tunable per integration via `HealthCheckSettings`.

--- a/docs/superpowers/specs/2026-07-05-transient-er-delivery-errors-design.md
+++ b/docs/superpowers/specs/2026-07-05-transient-er-delivery-errors-design.md
@@ -1,0 +1,193 @@
+# Design: Don't alarm on transient EarthRanger delivery failures
+
+**Date:** 2026-07-05
+**Status:** Approved for planning
+**Repos affected:** `cdip` (portal), `gundi-dispatcher-er` (this repo)
+
+## Problem
+
+EarthRanger's API often returns errors that are transient — server overload, temporary
+outages, gateway timeouts. The ER dispatcher publishes an `ObservationDeliveryFailed`
+event for every failed attempt and re-raises so GCP PubSub retries the message. The
+retry usually succeeds, but each failed attempt has already been recorded as an
+ERROR-level `ActivityLog` entry in the portal.
+
+Gundi's health calculator (`cdip/cdip_admin/integrations/models/v2/services.py::calculate_integration_status`)
+marks an integration UNHEALTHY when it sees ≥ `error_count_threshold` (default 3) ERROR
+logs within `time_window_minutes` (default 60). It never considers whether delivery
+eventually succeeded. The unhealthy status surfaces in the portal UI and in the
+scheduled alert email (`integrations/tasks.py::send_unhealthy_connections_email`).
+
+Two amplifiers make false alarms common:
+
+1. **Retries are invisible.** The dispatcher's push subscriptions (created in
+   `cdip/cdip_admin/deployments/tasks.py`) have a retry policy (10s–600s backoff) but no
+   dead-letter policy, so PubSub does not populate `deliveryAttempt` and the dispatcher
+   cannot distinguish a retry from a first attempt. Every redelivery of the *same*
+   failing message emits a fresh failure event — up to ~6 ERROR logs per hour from a
+   single stuck message, which alone crosses the default threshold.
+2. **Reference-data waits are logged as failures.** Event updates and attachments that
+   arrive before their parent observation raise `ReferenceDataError` ("Will retry
+   later") and publish failure events, even though this is normal out-of-order delivery.
+
+## Decision
+
+Classify retriable failures at the **portal event consumer** so they are logged as
+WARNING instead of ERROR (generalizing the existing ER-409 precedent), add a
+**WARNING-volume safety net** to the health calculator so sustained outages still
+alarm, and make the dispatcher emit a **final ERROR when it gives up** and
+dead-letters a message.
+
+Scope: the EarthRanger dispatcher path only (`origin=DISPATCHER` activity logs for ER
+destinations). Other dispatcher types and provider-side (pull action) errors are
+unchanged; the pattern can be extended later.
+
+## Component 1 — Portal consumer: classify retriable failures as WARNING
+
+**Where:** `cdip/cdip_admin/event_consumers/dispatcher_events_consumer.py`
+
+Replace the current special case (`"pamdas.org" in error and status == 409` → WARNING)
+with a shared helper applied in both `handle_observation_delivery_failed_event` and
+`handle_observation_update_failed_event`.
+
+A failure is **retriable** (log as WARNING) when the destination integration is an
+EarthRanger type and either:
+
+- `server_response_status ∈ {409, 429, 502, 503, 504}`, or
+- `server_response_status` is absent and the error string matches a transient pattern.
+  The dispatcher formats errors as `f"{type(e).__name__}: {e}"`, so exception class
+  names are reliable markers:
+  - erclient transient exceptions: `ERClientRateLimitExceeded`, `ERClientServiceUnreachable`
+  - raw transport failures: `ClientConnectorError`, `ServerTimeoutError`,
+    `ServerDisconnectedError`, `ClientOSError`, `TimeoutError`, `ConnectionResetError`
+  - the dispatcher's reference-data messages containing `"Will retry later"`
+    (an event update arriving before its parent event was delivered; early-arriving
+    attachments raise `ReferenceDataError` without publishing a portal event, so they
+    need no classification)
+
+Everything else stays ERROR, deliberately including:
+
+- **Plain 500 (`ERClientInternalError`)** — a deterministic 500 caused by a specific
+  payload should still alarm. (Revisit if ER overload proves to surface as 500s.)
+- **400/401/403/404** — bad request/auth/config problems are real and actionable.
+- **v1 legacy events** — they carry no status code; current behavior is preserved.
+- **Retries-exhausted events from Component 3.**
+
+ER scoping uses the destination integration's type (via the `GundiTrace` destination),
+not a URL substring, so self-hosted ER sites are covered. The activity-log `value`
+fields (`observation_delivery_failed`, `observation_update_failed`) and log payloads
+are unchanged — only `log_level` varies.
+
+## Component 2 — Health calculator: sustained-outage safety net
+
+**Where:** `cdip/cdip_admin/integrations/models/v2/services.py::calculate_integration_status`
+and `integrations/models/v2/models.py::HealthCheckSettings` (+ one migration)
+
+With Component 1 alone, an ER site that is hard-down for hours would produce only
+WARNINGs and never go unhealthy — silencing the one alarm that matters. Add a third
+condition to the calculator:
+
+- Count WARNING-level logs with `origin=DISPATCHER` and
+  `value ∈ {observation_delivery_failed, observation_update_failed}` in the same time
+  window. If the count ≥ a new `HealthCheckSettings.retriable_error_count_threshold`
+  (PositiveIntegerField, **default 30**), set UNHEALTHY with details like
+  `"Sustained delivery errors — destination may be down or overloaded"`.
+
+Calibration: one stuck message retrying at max backoff (600s) generates ~6 failure
+events per hour, so 30/hour ≈ 5+ messages failing concurrently — a real incident, not
+a blip. Tunable per integration like the existing settings.
+
+Ordering of checks: disabled → dispatcher deployment error → ERROR threshold →
+INTEGRATION-origin ERROR threshold (existing) → new WARNING threshold → healthy.
+
+## Component 3 — Dispatcher: ERROR when retries are exhausted
+
+**Where:** `gundi-dispatcher-er/core/services.py::process_request` (too-old branch,
+currently lines ~327-331)
+
+Messages that keep failing are retried until their original publish time exceeds
+`MAX_EVENT_AGE_SECONDS` (default 24h), at which point the dispatcher itself publishes
+them to the per-stream-type DLQ topic and acks — today **silently**, with no portal
+event.
+
+Change: when dead-lettering a too-old **v2** message, also publish a failure event to
+`DISPATCHER_EVENTS_TOPIC`:
+
+- `ObservationUpdateFailed` for `stream_type == event_update`, else
+  `ObservationDeliveryFailed`
+- error text: `"Delivery retries exhausted (message older than MAX_EVENT_AGE_SECONDS);
+  sent to dead-letter queue"`, no `server_response_status`
+
+The portal classifier (Component 1) will not match this as retriable, so it lands as
+one ERROR-level activity log — "we gave up on this message" becomes visible and counts
+toward the unhealthy threshold. No gundi-core schema change and no new event type.
+
+Out of scope for this component: the other DLQ paths (unsupported schema version,
+unknown event type) are code/config defects rather than delivery failures and keep
+current behavior; v1 messages keep current behavior. Failure to publish the event must
+not prevent the DLQ send/ack (wrap and log).
+
+## Behavior summary
+
+| Scenario | Today | After |
+|---|---|---|
+| ER returns 503/502/504/429/409, retry succeeds later | ERROR per attempt → unhealthy + email | WARNINGs; stays healthy |
+| Event update arrives before parent event ("Will retry later") | ERROR per attempt | WARNINGs; stays healthy |
+| ER hard-down for hours | unhealthy | unhealthy (≥30 WARNINGs in window) |
+| Message retried for 24h, then dead-lettered | silent (errors aged out of window) | one ERROR at DLQ time |
+| Bad credentials / 400 / 404 / plain 500 | ERROR → unhealthy | unchanged |
+| Non-ER destinations, v1 legacy events | ERROR | unchanged |
+
+## Testing
+
+**Portal (`cdip`):**
+- Consumer tests: each retriable status code → WARNING; each transient string pattern
+  → WARNING; "Will retry later" update-failed → WARNING; plain 500 / 401 / 400 → ERROR;
+  non-ER destination with 503 → ERROR (scoping); v1 event → ERROR; retries-exhausted
+  message → ERROR.
+- Health-calc tests: WARNINGs below threshold → healthy; ≥ threshold → unhealthy with
+  the new details string; interplay with the existing ERROR threshold; per-integration
+  override of the new setting.
+
+**Dispatcher (this repo):**
+- Extend `tests/test_dead_lettering.py`: too-old v2 message publishes both the DLQ
+  message and an `ObservationDeliveryFailed`; event-update variant publishes
+  `ObservationUpdateFailed`; publish failure of the event does not block the DLQ send;
+  v1 too-old message does not publish a failure event.
+
+## Rollout
+
+1. Portal deploy activates Components 1 and 2 immediately for **all existing ER
+   dispatcher functions** — no fleet redeploy (this is why classification lives in the
+   consumer rather than the dispatcher: there is one Cloud Function per destination).
+2. Component 3 ships with the next dispatcher release cycle.
+3. Tuning knobs, per integration, no code change: `error_count_threshold`,
+   `time_window_minutes`, new `retriable_error_count_threshold`.
+
+## Alternatives considered
+
+- **Dispatcher-side classification** (add `is_retriable` to `DeliveryErrorDetails` in
+  gundi-core): cleanest contract, but requires a gundi-core release plus redeploying
+  every per-destination function before it has any effect. Noted as a future contract
+  improvement.
+- **Retry-aware health calculator** (correlate failures with later successes via
+  `GundiTrace`): most faithful, but per-integration query complexity on a fleet-wide
+  scheduled task, and a success for one observation doesn't prove another failing one
+  is fine. Rejected for now.
+- **ERROR only when retries exhausted** (suppress intermediate attempts entirely):
+  requires the dispatcher to know the attempt number, which PubSub only exposes
+  (`deliveryAttempt`) when a dead-letter policy is set on the subscription. Adding a
+  dead-letter policy in `deployments/tasks.py` is a worthwhile future direction (native
+  retry caps + retry awareness) but changes retry semantics fleet-wide.
+
+## Implementation notes / verifications for the plan
+
+- Verify the ER integration type slug used for scoping (e.g. `earth_ranger`) against
+  the `Integration.type` model in cdip.
+- Verify the exact `value` field written by `handle_observation_update_failed_event`
+  (assumed `observation_update_failed`).
+- Verify which exception types `AsyncERClient` lets propagate for timeouts/connection
+  errors (the transport-pattern list above) before finalizing the pattern list.
+- The v2 attributes dict on the dispatcher side carries `gundi_id`, `related_to`,
+  `data_provider_id`, `destination_id`, `stream_type` — sufficient to build the
+  Component 3 event payloads without parsing the message body.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1430,3 +1430,31 @@ def observation_delivered_event(dispatched_observation):
     return system_events.ObservationDelivered(
         payload=dispatched_observation
     )
+
+
+def _make_request_too_old(request_fixture):
+    # Rewind publish_time so is_too_old() routes the message to the DLQ
+    json_data = request_fixture.get_json.return_value
+    old_publish_time = (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(seconds=settings.MAX_EVENT_AGE_SECONDS + 3600)
+    ).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    json_data["message"]["publish_time"] = old_publish_time
+    json_data["message"]["publishTime"] = old_publish_time
+    request_fixture.data = json.dumps(json_data)
+    return request_fixture
+
+
+@pytest.fixture
+def event_v2_as_pubsub_request_too_old(event_v2_as_pubsub_request):
+    return _make_request_too_old(event_v2_as_pubsub_request)
+
+
+@pytest.fixture
+def event_update_v2_as_pubsub_request_too_old(event_update_v2_as_pubsub_request):
+    return _make_request_too_old(event_update_v2_as_pubsub_request)
+
+
+@pytest.fixture
+def position_as_request_too_old(position_as_request):
+    return _make_request_too_old(position_as_request)

--- a/tests/test_dead_lettering.py
+++ b/tests/test_dead_lettering.py
@@ -1,7 +1,8 @@
 import pytest
 
 from core import settings
-from core.services import send_observation_to_dead_letter_topic
+from core.services import send_observation_to_dead_letter_topic, process_request
+from gundi_core import events as system_events
 
 
 @pytest.mark.parametrize(
@@ -35,3 +36,70 @@ async def test_send_observation_v2_to_dead_letter_topic(
     assert len(publish_calls) == 1, "Expected one publish call to the dead letter topic"
     call = publish_calls[0]
     assert call.args[0] == f"projects/{settings.GCP_PROJECT_ID}/topics/{expected_topic}"
+
+
+@pytest.mark.asyncio
+async def test_too_old_v2_event_publishes_retries_exhausted_error(
+        mocker, mock_pubsub_client, mock_publish_event, event_v2_as_pubsub_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    await process_request(event_v2_as_pubsub_request_too_old)
+
+    # The message was sent to the events DLQ topic
+    publish_calls = [c for c in mock_pubsub_client.PublisherClient.mock_calls if c[0] == "().publish"]
+    assert len(publish_calls) == 1
+    assert publish_calls[0].args[0] == f"projects/{settings.GCP_PROJECT_ID}/topics/{settings.EVENTS_DEAD_LETTER_TOPIC}"
+    # And a retries-exhausted failure event was published for the portal
+    assert mock_publish_event.called
+    call_kwargs = mock_publish_event.call_args.kwargs
+    event = call_kwargs["event"]
+    assert isinstance(event, system_events.ObservationDeliveryFailed)
+    assert "retries exhausted" in event.payload.error.lower()
+    assert event.payload.server_response_status is None
+    assert str(event.payload.observation.gundi_id) == "23ca4b15-18b6-4cf4-9da6-36dd69c6f638"
+    assert call_kwargs["topic_name"] == settings.DISPATCHER_EVENTS_TOPIC
+
+
+@pytest.mark.asyncio
+async def test_too_old_v2_event_update_publishes_update_failed_error(
+        mocker, mock_pubsub_client, mock_publish_event, event_update_v2_as_pubsub_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    await process_request(event_update_v2_as_pubsub_request_too_old)
+
+    assert mock_publish_event.called
+    event = mock_publish_event.call_args.kwargs["event"]
+    assert isinstance(event, system_events.ObservationUpdateFailed)
+    assert "retries exhausted" in event.payload.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_too_old_v1_message_does_not_publish_failure_event(
+        mocker, mock_pubsub_client, mock_publish_event, position_as_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    await process_request(position_as_request_too_old)
+
+    # v1 messages go to the legacy DLQ with no portal event (deprecated path)
+    publish_calls = [c for c in mock_pubsub_client.PublisherClient.mock_calls if c[0] == "().publish"]
+    assert len(publish_calls) == 1
+    assert publish_calls[0].args[0] == f"projects/{settings.GCP_PROJECT_ID}/topics/{settings.LEGACY_DEAD_LETTER_TOPIC}"
+    assert not mock_publish_event.called
+
+
+@pytest.mark.asyncio
+async def test_failure_publishing_retries_exhausted_event_does_not_raise(
+        mocker, mock_pubsub_client, mock_publish_event, event_v2_as_pubsub_request_too_old
+):
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mock_publish_event.side_effect = Exception("PubSub is down")
+    mocker.patch("core.services.publish_event", mock_publish_event)
+
+    # Must not raise: the DLQ send already succeeded and the message must be acked
+    await process_request(event_v2_as_pubsub_request_too_old)

--- a/tests/test_dead_lettering.py
+++ b/tests/test_dead_lettering.py
@@ -1,3 +1,6 @@
+import asyncio
+import time
+
 import pytest
 
 from core import settings
@@ -103,3 +106,25 @@ async def test_failure_publishing_retries_exhausted_event_does_not_raise(
 
     # Must not raise: the DLQ send already succeeded and the message must be acked
     await process_request(event_v2_as_pubsub_request_too_old)
+
+
+@pytest.mark.asyncio
+async def test_slow_event_publish_cannot_delay_the_dlq_ack(
+        mocker, mock_pubsub_client, event_v2_as_pubsub_request_too_old
+):
+    # publish_event retries with backoff (worst case ~65s); if the events
+    # topic is down, the retries-exhausted notification must be cut off by
+    # RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS so the function can return
+    # (ack) before the platform timeout would kill it.
+    async def hanging_publish(**kwargs):
+        await asyncio.sleep(30)
+
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    mocker.patch("core.services.publish_event", side_effect=hanging_publish)
+    mocker.patch.object(settings, "RETRIES_EXHAUSTED_PUBLISH_TIMEOUT_SECONDS", 0.05)
+
+    start = time.monotonic()
+    # Must neither raise nor hang: the DLQ send already happened and the
+    # message must be acked
+    await process_request(event_v2_as_pubsub_request_too_old)
+    assert time.monotonic() - start < 5


### PR DESCRIPTION
## Summary

Companion to PADAS/cdip#445 (portal side — deploy that first or together).

Messages that keep failing are retried by PubSub until older than `MAX_EVENT_AGE_SECONDS` (24h), then this function publishes them to the DLQ topic and acks — previously **silently**: no portal event, no activity log. With the portal now recording intermediate retriable failures as WARNINGs, the "we gave up on this message" moment must be the explicit ERROR.

- On the too-old DLQ path for **v2** messages, publish `ObservationDeliveryFailed` (or `ObservationUpdateFailed` for event updates) to `DISPATCHER_EVENTS_TOPIC` with error text `"Delivery retries exhausted (message older than N seconds). Message sent to dead-letter queue."` and no status code — the portal's classifier records it as one ERROR-level activity log.
- Event construction and publishing are wrapped so a publish failure can never block the DLQ ack (which would cause PubSub to redeliver and dead-letter the same message repeatedly).
- v1 legacy messages and the unparseable-message DLQ paths (unknown event type / schema version) are unchanged.

Also includes the design spec and implementation plan for the whole feature under `docs/superpowers/`.

## Testing

Full suite: 89 passed. New tests in `tests/test_dead_lettering.py` cover: too-old v2 event publishes the failure event + DLQ message, event-update variant publishes `ObservationUpdateFailed`, v1 publishes nothing (legacy DLQ only), and a publish failure does not raise (verified by mutation during review: removing the try/except makes the test fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112VwWNyti6VJbbKH7CrSDn