### PR TITLE
Fix main CI: service_root assertions vs re-published erclient 1.16.0

### DIFF
--- a/tests/test_er_auth.py
+++ b/tests/test_er_auth.py
@@ -465,7 +465,9 @@ def test_make_er_client_v1_normalizes_http_token_url_to_https():
         token=None,
     )
     client = ERDispatcher.make_er_client(config, "fake-provider")
-    assert client.service_root == "https://fake-site.pamdas.org/api/v1.0"
+    # Older erclient builds store the full API root verbatim; newer builds
+    # normalize service_root to the base URL. Assert the https upgrade only.
+    assert client.service_root.startswith("https://fake-site.pamdas.org")
     assert client.token_url == "https://fake-site.pamdas.org/oauth2/token"
 
 
@@ -476,7 +478,9 @@ def test_make_er_client_v2_normalizes_http_token_url_to_https(destination_integr
     client = ERDispatcherV2.make_er_client(
         integration=integration, provider="fake-provider"
     )
-    assert client.service_root == "https://gundi-load-testing.pamdas.org/api/v1.0"
+    # Older erclient builds store the full API root verbatim; newer builds
+    # normalize service_root to the base URL. Assert the https upgrade only.
+    assert client.service_root.startswith("https://gundi-load-testing.pamdas.org")
     assert client.token_url == "https://gundi-load-testing.pamdas.org/oauth2/token"
 
 


### PR DESCRIPTION
## Problem

Main's build fails on the two `test_make_er_client_*_normalizes_http_token_url_to_https` tests added in #42. Root cause: the `earthranger-client==1.16.0` artifact was **re-published with different code under the same version number**. Newer builds normalize `service_root` to the base URL (and append `/api/{version}` per request); older builds — like stale local venvs — store the full API root verbatim. The tests asserted the old storage format, so they pass locally against the old wheel and fail in CI against the fresh one.

The dispatcher itself is unaffected: the new client explicitly accepts and normalizes a full API root, and `token_url` is passed explicitly. Notably, the re-published wheel also adds the `retry_after` support on erclient exceptions, which is why `test_retry_after_from_erclient_drives_cooldown_ttl` now **passes** in CI (see GUNDI-5529 — that "failure on main" was the same stale-wheel drift in reverse).

## Fix

Assert the actual intent of the tests — the `http://` → `https://` upgrade — rather than the client's internal `service_root` storage format:
- `client.service_root.startswith("https://<host>")` (robust to both builds)
- `client.token_url == "https://<host>/oauth2/token"` (unchanged, exact)

## Testing

- Python 3.11 + freshly installed pinned requirements (CI-equivalent): **175 passed, 0 failed**
- Python 3.10 + older erclient wheel: 174 passed; only failure is the throttling `retry_after` test, which requires the newer wheel (fix your venv with `pip install --force-reinstall earthranger-client==1.16.0`)

Follow-up worth considering: republishing a package under an unchanged version number breaks reproducibility — erclient changes should get a real version bump (and/or this repo should pin by hash). Noted on GUNDI-5529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)