### PR TITLE
Bulk-post observation batch envelopes to EarthRanger

### DIFF
--- a/core/dispatchers.py
+++ b/core/dispatchers.py
@@ -331,13 +331,26 @@ class ERObservationsBatchDispatcher(ERDispatcherV2):
     async def _send(self, observations, **kwargs):
         # observations: List[schemas.v2.ERObservation] sharing this client's
         # provider_key. Posted as a single JSON array to the ER sensors endpoint.
+        #
+        # NOTE: we deliberately do NOT call client.post_sensor_observation()
+        # with a list. erclient 1.16.0's implementation has a parameter-
+        # rebinding bug: it cleans each item in a for-loop over
+        # `observation`, which shadows its own list-vs-single argument, so
+        # the payload it actually posts is the LAST element only, not the
+        # list. Until a fixed erclient ships, replicate the intended
+        # behavior directly against the pinned client's building blocks.
         async with self.er_client as client:
             try:
                 observations_cleaned = [
                     json.loads(o.json(exclude_none=True, exclude_unset=True))
                     for o in observations
                 ]
-                return await client.post_sensor_observation(observations_cleaned)
+                for obs in observations_cleaned:
+                    client._clean_observation(obs)
+                return await client._post(
+                    f"sensors/generic/{client.provider_key}/status",
+                    payload=observations_cleaned,
+                )
             except Exception as ex:
                 logger.exception(
                     f"Error sending observations batch to {client.service_root}: \n{type(ex)}: {ex}"

--- a/core/dispatchers.py
+++ b/core/dispatchers.py
@@ -326,6 +326,25 @@ class ERObservationDispatcher(ERDispatcherV2):
                 raise ex
 
 
+class ERObservationsBatchDispatcher(ERDispatcherV2):
+
+    async def _send(self, observations, **kwargs):
+        # observations: List[schemas.v2.ERObservation] sharing this client's
+        # provider_key. Posted as a single JSON array to the ER sensors endpoint.
+        async with self.er_client as client:
+            try:
+                observations_cleaned = [
+                    json.loads(o.json(exclude_none=True, exclude_unset=True))
+                    for o in observations
+                ]
+                return await client.post_sensor_observation(observations_cleaned)
+            except Exception as ex:
+                logger.exception(
+                    f"Error sending observations batch to {client.service_root}: \n{type(ex)}: {ex}"
+                )
+                raise ex
+
+
 class ERMessageDispatcher(ERDispatcherV2):
 
     async def _send(self, message: schemas.v2.ERMessage, **kwargs):

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -60,6 +60,34 @@ async def publish_throttling_notice(attributes: dict, scope: str):
         logger.exception(f"Error publishing throttling notice: {e}")
 
 
+async def publish_batch_dead_lettered_notice(attributes: dict):
+    # Batch envelopes carry no gundi_id in their attributes, so
+    # publish_retries_exhausted_event (which requires one) bails out for
+    # them with just a warning log - the age-out would otherwise be
+    # completely silent: no activity-log entry, no failure event, and up to
+    # OBSERVATIONS_BATCH_MAX_ITEMS observations simply vanish with no trace.
+    title = (
+        "Observations batch dead-lettered after retries "
+        f"(batch_count={attributes.get('batch_count')})"
+    )
+    try:
+        await publish_event(
+            event=system_events.DispatcherCustomLog(
+                payload=gundi_schemas_v2.CustomDispatcherLog(
+                    gundi_id=None,
+                    related_to=attributes.get("related_to"),
+                    data_provider_id=attributes.get("data_provider_id"),
+                    destination_id=attributes.get("destination_id"),
+                    title=title,
+                    level=LogLevel.ERROR,
+                )
+            ),
+            topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+        )
+    except Exception as e:
+        logger.exception(f"Error publishing batch dead-lettered notice: {e}")
+
+
 async def dispatch_transformed_observation_v2(observation, attributes: dict):
     with tracing.tracer.start_as_current_span(
             "er_dispatcher.dispatch_transformed_observation", kind=SpanKind.CLIENT
@@ -327,7 +355,12 @@ async def handle_er_message(event: MessageTransformedER, attributes: dict):
 
 # ER status codes that mean the payload itself is bad: retrying the same
 # bytes can never succeed, so shrink the batch instead of nacking it.
-PERMANENT_ER_STATUS_CODES = {400, 403}
+# 403 is deliberately NOT here: it's typically an auth/permission condition
+# (revoked token, provider key not yet authorized) that is recoverable once
+# fixed, and the single-item path already retries it for 24h - treating it
+# as permanent here would turn a fixable config error into permanent data
+# loss for every item in the batch.
+PERMANENT_ER_STATUS_CODES = {400}
 
 
 def _chunked(items, size):
@@ -383,7 +416,13 @@ def _cache_item_as_dispatched(batch, item):
             data_provider_id=batch.data_provider_id,
             destination_id=batch.destination_id,
             delivered_at=datetime.now(timezone.utc),
-        )
+        ),
+        # Longer TTL than the single-item path: this cache is what makes
+        # envelope redelivery idempotent (see is_observation_dispatched), and
+        # PubSub keeps retrying for MAX_EVENT_AGE_SECONDS (24h) - a shorter
+        # TTL would silently expire the skip-cache mid-retry-window and
+        # re-post already-delivered items as duplicates.
+        ttl=settings.DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL,
     )
 
 
@@ -410,15 +449,26 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
         ]
         current_span.set_attribute("pending_count", len(pending))
         if not pending:
+            # Everything is already cached as dispatched, but the original
+            # attempt may have died after caching and before publishing
+            # ObservationsBatchDelivered (e.g. function timeout). Publish for
+            # ALL items so trace stamping isn't lost forever on redelivery —
+            # the portal handler is idempotent against repeat events.
             logger.info(f"All items in batch {batch.batch_id} already delivered. Skipping.")
+            await _publish_batch_delivered(batch, [str(item.gundi_id) for item in batch.items])
             return
 
-        dispatcher = dispatchers.ERObservationsBatchDispatcher(
-            integration=destination_integration,
-            provider=batch.provider_key,
-        )
         delivered_gundi_ids = []
         for chunk in _chunked(pending, settings.ER_BULK_SIZE):
+            # A fresh dispatcher (and so a fresh underlying http client) per
+            # chunk: _send's `async with self.er_client` permanently closes
+            # the client on exit, so reusing one dispatcher across chunks
+            # would make every chunk after the first raise on a closed
+            # client (see C2 in the final review).
+            dispatcher = dispatchers.ERObservationsBatchDispatcher(
+                integration=destination_integration,
+                provider=batch.provider_key,
+            )
             try:
                 await dispatcher.send([item.observation for item in chunk])
             except Exception as e:
@@ -431,11 +481,13 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                         f"Bulk post rejected ({status_code}) for batch {batch.batch_id}. "
                         f"Falling back to per-item posts for {len(chunk)} items."
                     )
-                    single_dispatcher = dispatchers.ERObservationDispatcher(
-                        integration=destination_integration,
-                        provider=batch.provider_key,
-                    )
                     for item in chunk:
+                        # Fresh client per item too, for the same reason as
+                        # above (each single_dispatcher.send closes its client).
+                        single_dispatcher = dispatchers.ERObservationDispatcher(
+                            integration=destination_integration,
+                            provider=batch.provider_key,
+                        )
                         try:
                             await single_dispatcher.send(item.observation)
                         except Exception as item_exc:

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -10,6 +10,9 @@ from gundi_core.events.transformers import (
     ObservationTransformedER,
     MessageTransformedER
 )
+# NOTE: ObservationsBatchTransformedER lives in gundi_core.events.batches, not
+# .transformers (verified against gundi_core 1.13.0's actual module layout).
+from gundi_core.events import ObservationsBatchTransformedER
 from core import tracing, dispatchers, settings, throttling
 from core.errors import ReferenceDataError, DispatcherException
 from core.utils import (
@@ -17,6 +20,7 @@ from core.utils import (
     get_integration_details,
     get_dispatched_observation,
     cache_dispatched_observation,
+    is_observation_dispatched,
     is_null,
     publish_event,
 )
@@ -320,11 +324,169 @@ async def handle_er_message(event: MessageTransformedER, attributes: dict):
         current_span.set_attribute("payload", repr(event.payload))
         return await dispatch_transformed_observation_v2(observation=event.payload, attributes=attributes)
 
+
+# ER status codes that mean the payload itself is bad: retrying the same
+# bytes can never succeed, so shrink the batch instead of nacking it.
+PERMANENT_ER_STATUS_CODES = {400, 403}
+
+
+def _chunked(items, size):
+    for start in range(0, len(items), size):
+        yield items[start:start + size]
+
+
+async def _publish_batch_delivered(batch, delivered_gundi_ids):
+    if not delivered_gundi_ids:
+        return
+    await publish_event(
+        event=system_events.ObservationsBatchDelivered(
+            payload=system_events.ObservationsBatchDeliveryDetails(
+                batch_id=batch.batch_id,
+                data_provider_id=batch.data_provider_id,
+                destination_id=batch.destination_id,
+                delivered_at=datetime.now(timezone.utc),
+                gundi_ids=delivered_gundi_ids,
+            )
+        ),
+        topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+    )
+
+
+async def _publish_item_delivery_failed(batch, item, exception):
+    await publish_event(
+        event=system_events.ObservationDeliveryFailed(
+            payload=DeliveryErrorDetails(
+                error=f"{type(exception).__name__}: {exception}",
+                error_traceback=traceback.format_exc(),
+                server_response_status=getattr(exception, "status_code", None),
+                server_response_body=getattr(exception, "response_body", ""),
+                observation=gundi_schemas_v2.DispatchedObservation(
+                    gundi_id=item.gundi_id,
+                    related_to=None,
+                    external_id=None,
+                    data_provider_id=batch.data_provider_id,
+                    destination_id=batch.destination_id,
+                    delivered_at=datetime.now(timezone.utc),
+                ),
+            )
+        ),
+        topic_name=settings.DISPATCHER_EVENTS_TOPIC,
+    )
+
+
+def _cache_item_as_dispatched(batch, item):
+    cache_dispatched_observation(
+        observation=gundi_schemas_v2.DispatchedObservation(
+            gundi_id=item.gundi_id,
+            related_to=None,
+            external_id=None,  # By design: ER bulk responses carry no reliable per-item IDs
+            data_provider_id=batch.data_provider_id,
+            destination_id=batch.destination_id,
+            delivered_at=datetime.now(timezone.utc),
+        )
+    )
+
+
+async def dispatch_observations_batch_v2(batch, attributes: dict):
+    with tracing.tracer.start_as_current_span(
+            "er_dispatcher.dispatch_observations_batch", kind=SpanKind.CLIENT
+    ) as current_span:
+        destination_id = str(batch.destination_id)
+        stream_type = gundi_schemas_v2.StreamPrefixEnum.observation.value
+        current_span.set_attribute("batch_id", str(batch.batch_id))
+        current_span.set_attribute("destination_id", destination_id)
+        current_span.set_attribute("batch_count", len(batch.items))
+
+        destination_integration = await get_integration_details(integration_id=destination_id)
+        if not destination_integration:
+            error_msg = f"No destination config details found for destination_id {destination_id}"
+            logger.error(error_msg)
+            raise ReferenceDataError(error_msg)
+
+        # Skip items already delivered — makes envelope redelivery idempotent
+        pending = [
+            item for item in batch.items
+            if not is_observation_dispatched(gundi_id=str(item.gundi_id), destination_id=destination_id)
+        ]
+        current_span.set_attribute("pending_count", len(pending))
+        if not pending:
+            logger.info(f"All items in batch {batch.batch_id} already delivered. Skipping.")
+            return
+
+        dispatcher = dispatchers.ERObservationsBatchDispatcher(
+            integration=destination_integration,
+            provider=batch.provider_key,
+        )
+        delivered_gundi_ids = []
+        for chunk in _chunked(pending, settings.ER_BULK_SIZE):
+            try:
+                await dispatcher.send([item.observation for item in chunk])
+            except Exception as e:
+                status_code = getattr(e, "status_code", None)
+                error = f"{type(e).__name__}: {e}"
+                if status_code in PERMANENT_ER_STATUS_CODES:
+                    # Permanent: shrink the batch — post items individually so
+                    # the poison record(s) get identified and failed alone.
+                    logger.warning(
+                        f"Bulk post rejected ({status_code}) for batch {batch.batch_id}. "
+                        f"Falling back to per-item posts for {len(chunk)} items."
+                    )
+                    single_dispatcher = dispatchers.ERObservationDispatcher(
+                        integration=destination_integration,
+                        provider=batch.provider_key,
+                    )
+                    for item in chunk:
+                        try:
+                            await single_dispatcher.send(item.observation)
+                        except Exception as item_exc:
+                            logger.warning(
+                                f"Observation {item.gundi_id} in batch {batch.batch_id} failed individually: {item_exc}"
+                            )
+                            await _publish_item_delivery_failed(batch, item, item_exc)
+                        else:
+                            _cache_item_as_dispatched(batch, item)
+                            delivered_gundi_ids.append(str(item.gundi_id))
+                else:
+                    # Transient: record distress, report partial progress, and
+                    # nack the envelope. Redelivery skips delivered items via
+                    # the dispatched-observation cache.
+                    notify_scope = throttling.record_distress(
+                        destination_id=destination_id,
+                        stream_type=stream_type,
+                        status_code=status_code,
+                        error=error,
+                        retry_after=getattr(e, "retry_after", None),
+                    )
+                    if notify_scope:
+                        await publish_throttling_notice(attributes=attributes, scope=notify_scope)
+                    await _publish_batch_delivered(batch, delivered_gundi_ids)
+                    raise DispatcherException(
+                        f"Transient error dispatching batch {batch.batch_id}: {error}"
+                    )
+            else:
+                for item in chunk:
+                    _cache_item_as_dispatched(batch, item)
+                    delivered_gundi_ids.append(str(item.gundi_id))
+                throttling.record_success(destination_id=destination_id, stream_type=stream_type)
+
+        current_span.set_attribute("delivered_count", len(delivered_gundi_ids))
+        await _publish_batch_delivered(batch, delivered_gundi_ids)
+
+
+async def handle_er_observations_batch(event: ObservationsBatchTransformedER, attributes: dict):
+    with tracing.tracer.start_as_current_span(
+            "er_dispatcher.handle_er_observations_batch", kind=SpanKind.CONSUMER
+    ) as current_span:
+        current_span.set_attribute("batch_count", len(event.payload.items))
+        return await dispatch_observations_batch_v2(batch=event.payload, attributes=attributes)
+
+
 event_schemas = {
     "EventTransformedER": EventTransformedER,
     "EventUpdateTransformedER": EventUpdateTransformedER,
     "AttachmentTransformedER": AttachmentTransformedER,
     "ObservationTransformedER": ObservationTransformedER,
+    "ObservationsBatchTransformedER": ObservationsBatchTransformedER,
     "MessageTransformedER": MessageTransformedER
 }
 
@@ -333,5 +495,6 @@ event_handlers = {
     "EventUpdateTransformedER": handle_er_event_update,
     "AttachmentTransformedER": handle_er_attachment,
     "ObservationTransformedER": handle_er_observation,
+    "ObservationsBatchTransformedER": handle_er_observations_batch,
     "MessageTransformedER": handle_er_message
 }

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -481,6 +481,7 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                         f"Bulk post rejected ({status_code}) for batch {batch.batch_id}. "
                         f"Falling back to per-item posts for {len(chunk)} items."
                     )
+                    fallback_delivered_any = False
                     for item in chunk:
                         # Fresh client per item too, for the same reason as
                         # above (each single_dispatcher.send closes its client).
@@ -498,6 +499,15 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                         else:
                             _cache_item_as_dispatched(batch, item)
                             delivered_gundi_ids.append(str(item.gundi_id))
+                            fallback_delivered_any = True
+                    if fallback_delivered_any:
+                        # A successful fallback delivery proves the site is
+                        # reachable, same as a successful bulk chunk — clear
+                        # any lingering cooldown instead of leaving the
+                        # destination throttled.
+                        throttling.record_success(
+                            destination_id=destination_id, stream_type=stream_type
+                        )
                 else:
                     # Transient: record distress, report partial progress, and
                     # nack the envelope. Redelivery skips delivered items via

--- a/core/services.py
+++ b/core/services.py
@@ -407,9 +407,14 @@ async def process_request(request):
             # Admission gate: defer over-cap / cooling-down destinations.
             # Runs after the too-old check above so exhausted messages always
             # dead-letter instead of being nacked past PubSub retention.
+            try:
+                admission_amount = int(attributes.get("batch_count") or 1)
+            except (TypeError, ValueError):
+                admission_amount = 1
             await throttling.check_admission(
                 destination_id=attributes.get("destination_id"),
                 stream_type=attributes.get("stream_type"),
+                amount=admission_amount,
             )
             await process_transformer_event_v2(transformed_observation, attributes)
         else:  # Default to v1

--- a/core/services.py
+++ b/core/services.py
@@ -22,7 +22,7 @@ from core.utils import (
 from .errors import DispatcherException, ReferenceDataError
 from . import tracing
 from . import settings
-from .event_handlers import event_handlers, event_schemas
+from .event_handlers import event_handlers, event_schemas, publish_batch_dead_lettered_notice
 
 
 logger = logging.getLogger(__name__)
@@ -400,7 +400,13 @@ async def process_request(request):
             current_span.set_attribute("is_too_old", True)
             await send_observation_to_dead_letter_topic(transformed_observation, attributes)
             if attributes.get("gundi_version", "v1") == "v2":
-                await publish_retries_exhausted_event(attributes)
+                if attributes.get("batch") == "true":
+                    # publish_retries_exhausted_event requires a gundi_id,
+                    # which batch envelopes don't carry in their attributes -
+                    # without this, a batch age-out is completely silent.
+                    await publish_batch_dead_lettered_notice(attributes)
+                else:
+                    await publish_retries_exhausted_event(attributes)
             return  # Skip the event
         # Process the event according to the gundi version
         if attributes.get("gundi_version", "v1") == "v2":

--- a/core/settings.py
+++ b/core/settings.py
@@ -52,6 +52,9 @@ ER_TOKEN_CACHE_SECRET = env.str("ER_TOKEN_CACHE_SECRET", "")
 # N-seconds to cache portal responses for configuration objects.
 PORTAL_CONFIG_OBJECT_CACHE_TTL = env.int("PORTAL_CONFIG_OBJECT_CACHE_TTL", 60)
 DISPATCHED_OBSERVATIONS_CACHE_TTL = env.int("PORTAL_CONFIG_OBJECT_CACHE_TTL", 60 * 60)  # 1 Hour
+# Idempotency cache for batch-delivered observations. Must exceed the PubSub
+# retry window (24h) so envelope redeliveries keep skipping delivered items.
+DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL = env.int("DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL", 90000)
 
 # Used in OTel traces/spans to set the 'environment' attribute, used on metrics calculation
 TRACE_ENVIRONMENT = env.str("TRACE_ENVIRONMENT", "dev")

--- a/core/settings.py
+++ b/core/settings.py
@@ -83,3 +83,8 @@ THROTTLE_COOLDOWN_BASE_SECONDS = env.int("THROTTLE_COOLDOWN_BASE_SECONDS", 30)
 THROTTLE_COOLDOWN_MAX_SECONDS = env.int("THROTTLE_COOLDOWN_MAX_SECONDS", 600)
 THROTTLE_COOLDOWN_LEVEL_TTL_SECONDS = env.int("THROTTLE_COOLDOWN_LEVEL_TTL_SECONDS", 900)
 THROTTLE_NOTIFY_TTL_SECONDS = env.int("THROTTLE_NOTIFY_TTL_SECONDS", 300)
+
+# Batch delivery (see cdip repo: docs/superpowers/specs/2026-07-29-pipeline-batch-envelope-design.md)
+# Max observations per single ER bulk request. Independent from the envelope
+# size chosen upstream; an envelope larger than this is posted in sub-chunks.
+ER_BULK_SIZE = env.int("ER_BULK_SIZE", 200)

--- a/core/settings.py
+++ b/core/settings.py
@@ -90,4 +90,6 @@ THROTTLE_NOTIFY_TTL_SECONDS = env.int("THROTTLE_NOTIFY_TTL_SECONDS", 300)
 # Batch delivery (see cdip repo: docs/superpowers/specs/2026-07-29-pipeline-batch-envelope-design.md)
 # Max observations per single ER bulk request. Independent from the envelope
 # size chosen upstream; an envelope larger than this is posted in sub-chunks.
-ER_BULK_SIZE = env.int("ER_BULK_SIZE", 200)
+# max(1, ...): a zero/negative misconfiguration would make the chunking step
+# (range with step=ER_BULK_SIZE) raise at runtime.
+ER_BULK_SIZE = max(1, env.int("ER_BULK_SIZE", 200))

--- a/core/throttling.py
+++ b/core/throttling.py
@@ -68,7 +68,7 @@ def _rate_key(destination_id, family, window):
     return f"throttle:rate:{destination_id}:{family}:{window}"
 
 
-def _evaluate(destination_id, family):
+def _evaluate(destination_id, family, amount=1):
     # Returns (admitted, reason, retry_after). Plain commands instead of a Lua
     # script: INCR is atomic, and the check-then-increment race admits at most
     # a few extra messages — acceptable for a kindness cap, and it keeps this
@@ -83,8 +83,9 @@ def _evaluate(destination_id, family):
             return False, "cooldown", ttl
     now = int(time.time())
     rate_key = _rate_key(destination_id, family, now // 60)
-    count = db.incr(rate_key)
-    if count == 1:
+    count = db.incr(rate_key, amount)
+    if count == amount:
+        # First increment of this window (whatever its size).
         # Two windows so a straggler INCR never resurrects an expired key
         db.expire(rate_key, 120)
     if count <= _cap_for_family(family):
@@ -92,19 +93,21 @@ def _evaluate(destination_id, family):
     return False, "rate", 60 - (now % 60)
 
 
-async def check_admission(destination_id, stream_type):
+async def check_admission(destination_id, stream_type, amount=1):
     # Raises ThrottledMessage when the message must be deferred (nacked).
+    # `amount` is the number of items the message carries (1 for classic
+    # single-observation messages, N for batch envelopes).
     if not settings.THROTTLING_ENABLED or not destination_id:
         return
     family = get_family(stream_type)
     try:
-        admitted, reason, retry_after = _evaluate(destination_id, family)
+        admitted, reason, retry_after = _evaluate(destination_id, family, amount)
         if admitted:
             return
         if reason == "rate" and retry_after <= settings.THROTTLE_GRACE_WAIT_MAX_SECONDS:
             # The window opens soon: wait it out instead of paying a redelivery
             await asyncio.sleep(retry_after)
-            admitted, reason, retry_after = _evaluate(destination_id, family)
+            admitted, reason, retry_after = _evaluate(destination_id, family, amount)
             if admitted:
                 return
     except Exception as e:

--- a/core/throttling.py
+++ b/core/throttling.py
@@ -108,6 +108,12 @@ async def check_admission(destination_id, stream_type, amount=1):
     # single-observation messages, N for batch envelopes).
     if not settings.THROTTLING_ENABLED or not destination_id:
         return
+    # Clamp so a malformed batch_count (0, negative, or non-int) can never
+    # turn INCRBY into a no-op or a decrement that corrupts the rate counter.
+    try:
+        amount = max(1, int(amount))
+    except (TypeError, ValueError):
+        amount = 1
     family = get_family(stream_type)
     try:
         admitted, reason, retry_after = _evaluate(destination_id, family, amount)

--- a/core/throttling.py
+++ b/core/throttling.py
@@ -88,7 +88,16 @@ def _evaluate(destination_id, family, amount=1):
         # First increment of this window (whatever its size).
         # Two windows so a straggler INCR never resurrects an expired key
         db.expire(rate_key, 120)
-    if count <= _cap_for_family(family):
+    # Admit whenever there was headroom BEFORE this increment (count - amount
+    # is the window's prior total), not whenever the post-increment total
+    # fits under the cap. A batch larger than the cap (amount > cap) can
+    # never satisfy `count <= cap`, so the old check deferred it forever -
+    # every retry lands at the same over-cap count and it's never admitted,
+    # until the message ages out and is silently dead-lettered. Admitting on
+    # prior headroom guarantees progress for any batch size, overshooting
+    # the cap by at most one batch, while single-item traffic (amount=1) is
+    # unaffected: count - 1 < cap is equivalent to count <= cap.
+    if count - amount < _cap_for_family(family):
         return True, None, None
     return False, "rate", 60 - (now % 60)
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -368,6 +368,11 @@ def cache_dispatched_observation(
         observation: gundi_schemas_v2.DispatchedObservation,
         ttl: int = None,
 ):
+    # Defined before the try so the except handlers below can always
+    # reference it, even when the failure happens while reading the
+    # observation's fields (an undefined extra_dict would otherwise raise
+    # UnboundLocalError and mask the original error).
+    extra_dict = {}
     try:
         gundi_id = str(observation.gundi_id)
         destination_id = str(observation.destination_id)

--- a/core/utils.py
+++ b/core/utils.py
@@ -396,6 +396,20 @@ def cache_dispatched_observation(
         )
 
 
+def is_observation_dispatched(gundi_id, destination_id) -> bool:
+    # Cache-only check used by the batch path to skip already-delivered items
+    # on envelope redelivery. Unlike get_dispatched_observation, this must NOT
+    # fall back to a portal query — a large batch would turn one cache outage
+    # into hundreds of portal calls. Fail open: worst case an item is re-posted
+    # and ER receives a duplicate observation.
+    try:
+        cache_key = f"dispatched_observation.{gundi_id}.{destination_id}"
+        return bool(_cache_db.get(cache_key))
+    except Exception as e:
+        logger.warning(f"Error reading dispatched-observation cache: {e}")
+        return False
+
+
 def extract_fields_from_message(message):
     if message:
         data = base64.b64decode(message.get("data", "").encode('utf-8'))

--- a/core/utils.py
+++ b/core/utils.py
@@ -366,6 +366,7 @@ async def get_dispatched_observation(gundi_id: str, destination_id: str) -> gund
 
 def cache_dispatched_observation(
         observation: gundi_schemas_v2.DispatchedObservation,
+        ttl: int = None,
 ):
     try:
         gundi_id = str(observation.gundi_id)
@@ -381,7 +382,7 @@ def cache_dispatched_observation(
         cache_key = f"dispatched_observation.{gundi_id}.{destination_id}"
         _cache_db.setex(
             name=cache_key,
-            time=settings.DISPATCHED_OBSERVATIONS_CACHE_TTL,
+            time=ttl if ttl is not None else settings.DISPATCHED_OBSERVATIONS_CACHE_TTL,
             value=observation.json()
         )
     except redis_exceptions.ConnectionError as e:

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ functions-framework==3.*
 walrus==0.9.5
 earthranger-client==1.16.0
 https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.5.6/cdip_connector-1.5.6-py3-none-any.whl
-gundi-core==1.11.2
+gundi-core==1.13.0
 gundi-client==1.0.4
 gundi-client-v2==2.4.0
 opentelemetry-api==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,7 +126,7 @@ gundi-client==1.0.4
     #   cdip-connector
 gundi-client-v2==2.4.0
     # via -r requirements.in
-gundi-core==1.11.2
+gundi-core==1.13.0
     # via
     #   -r requirements.in
     #   cdip-connector

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,6 +267,9 @@ def mock_erclient_class(
     erclient_mock.close.return_value = async_return(
         er_client_close_response
     )
+    # ERObservationsBatchDispatcher._send bypasses post_sensor_observation
+    # (see C1 fix note in core/dispatchers.py) and calls _post directly.
+    erclient_mock._post.return_value = async_return(post_sensor_observation_response)
     erclient_mock.__aenter__.return_value = erclient_mock
     erclient_mock.__aexit__.return_value = er_client_close_response
     mocked_erclient_class.return_value = erclient_mock

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -11,9 +11,11 @@ from core.dispatchers import (
     EREventAttachmentDispatcher,
     EREventUpdateDispatcher,
     ERObservationDispatcher,
+    ERObservationsBatchDispatcher,
 )
 from core.errors import DispatcherException
 from core.event_handlers import dispatch_transformed_observation_v2
+from gundi_core.schemas.v2 import ERObservation
 
 
 async def _test_dispatcher_on_errors(
@@ -288,3 +290,85 @@ async def test_v2_dispatcher_does_not_retry_static_token_client_on_bad_credentia
 
     assert erclient_mock.post_report.await_count == 1
     mock_cache_empty.delete.assert_not_called()
+
+
+class _RebuggyFakeERClient:
+    """A double for erclient's AsyncERClient that faithfully reproduces the
+    real 1.16.0 `post_sensor_observation` parameter-rebinding bug (it posts
+    only the LAST element of a list, see core/dispatchers.py's
+    ERObservationsBatchDispatcher._send comment). A permissive MagicMock
+    can't catch a regression back to calling post_sensor_observation with a
+    list, because it would happily "accept" the list without exercising the
+    real library's buggy loop. This double does, by actually reimplementing
+    that loop.
+    """
+
+    def __init__(self, provider_key=None):
+        self.provider_key = provider_key
+        self.service_root = "https://fake-site.pamdas.org/api/v1.0"
+        self.username = None
+        self.posted_payloads = []  # every payload handed to _post
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def _clean_observation(self, observation):
+        if hasattr(observation.get("recorded_at"), "isoformat"):
+            observation["recorded_at"] = observation["recorded_at"].isoformat()
+        return observation
+
+    async def _post(self, path, payload, params=None):
+        self.posted_payloads.append(payload)
+        return {"result": "ok"}
+
+    async def post_sensor_observation(self, observation, sensor_type="generic"):
+        # Faithful reproduction of erclient 1.16.0's bug: `observation` gets
+        # rebound by the loop, so only the last item is ever posted.
+        observations_list = observation if isinstance(observation, (list, set)) else [observation]
+        for observation in observations_list:
+            self._clean_observation(observation)
+        return await self._post(
+            f"sensors/{sensor_type}/{self.provider_key}/status", payload=observation
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_dispatcher_posts_full_list_not_just_last_item(
+    mocker,
+    destination_integration_v2,
+):
+    # C1 regression test: assert the payload ACTUALLY handed to the client
+    # is the full list of observations, using a double that reproduces
+    # erclient's real bug instead of a permissive MagicMock (which would
+    # hide this class of bug entirely).
+    fake_client = _RebuggyFakeERClient()
+    mocker.patch(
+        "core.dispatchers.TokenCachingAsyncERClient",
+        mocker.MagicMock(return_value=fake_client),
+    )
+    observations = [
+        ERObservation(
+            manufacturer_id=f"device-{i}",
+            source_type="tracking-device",
+            subject_name=f"subject-{i}",
+            recorded_at="2026-07-22 11:51:05+00:00",
+            location={"lon": -72.7, "lat": -51.6},
+            additional={"speed_kmph": 30},
+        )
+        for i in range(3)
+    ]
+    dispatcher = ERObservationsBatchDispatcher(
+        integration=destination_integration_v2, provider="test_provider"
+    )
+
+    await dispatcher.send(observations)
+
+    # Exactly one post, and it carries all 3 items - not just the last one.
+    assert len(fake_client.posted_payloads) == 1
+    posted = fake_client.posted_payloads[0]
+    assert isinstance(posted, list)
+    assert len(posted) == 3
+    assert [o["manufacturer_id"] for o in posted] == ["device-0", "device-1", "device-2"]

--- a/tests/test_process_observation_batches_v2.py
+++ b/tests/test_process_observation_batches_v2.py
@@ -95,12 +95,14 @@ async def test_process_observations_batch_posts_one_bulk_request(
 
     await process_request(_make_batch_request(mocker, items_count=3))
 
-    # ONE bulk post for the whole envelope
-    post_mock = mock_erclient_class.return_value.post_sensor_observation
+    # ONE bulk post for the whole envelope, sent via _post (not
+    # post_sensor_observation - see C1 fix note in core/dispatchers.py)
+    post_mock = mock_erclient_class.return_value._post
     assert post_mock.call_count == 1
-    (posted,) = post_mock.call_args.args
+    posted = post_mock.call_args.kwargs["payload"]
     assert isinstance(posted, list)
     assert len(posted) == 3
+    assert not mock_erclient_class.return_value.post_sensor_observation.called
     # Every item cached as dispatched
     assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 3
     # One ObservationsBatchDelivered event published
@@ -124,7 +126,7 @@ async def test_batch_respects_er_bulk_size(
 
     await process_request(_make_batch_request(mocker, items_count=3))
 
-    post_mock = mock_erclient_class.return_value.post_sensor_observation
+    post_mock = mock_erclient_class.return_value._post
     assert post_mock.call_count == 2  # 2 + 1
 
 
@@ -148,8 +150,8 @@ async def test_batch_skips_already_delivered_items(
 
     await process_request(_make_batch_request(mocker, items_count=3))
 
-    post_mock = mock_erclient_class.return_value.post_sensor_observation
-    (posted,) = post_mock.call_args.args
+    post_mock = mock_erclient_class.return_value._post
+    posted = post_mock.call_args.kwargs["payload"]
     assert len(posted) == 2
 
 
@@ -167,7 +169,7 @@ async def test_batch_transient_error_raises_for_redelivery(
     mocker.patch("core.utils.pubsub", mock_pubsub_client)
     err = ERClientException("ER error ON POST: service unavailable")
     err.status_code = 503
-    mock_erclient_class.return_value.post_sensor_observation.side_effect = err
+    mock_erclient_class.return_value._post.side_effect = err
 
     with pytest.raises(Exception):
         await process_request(_make_batch_request(mocker, items_count=3))
@@ -194,10 +196,13 @@ async def test_batch_400_falls_back_to_per_item_and_acks(
     bulk_err.status_code = 400
     item_err = ERClientException("ER error ON POST: bad payload")
     item_err.status_code = 400
-    post_mock = mock_erclient_class.return_value.post_sensor_observation
-    # Bulk call fails with 400; per-item fallback: item0 ok, item1 fails, item2 ok
-    post_mock.side_effect = [
-        bulk_err,
+    # Bulk call (via _post) fails with 400; per-item fallback (via
+    # post_sensor_observation, ERObservationDispatcher's single-item path):
+    # item0 ok, item1 fails, item2 ok
+    bulk_post_mock = mock_erclient_class.return_value._post
+    bulk_post_mock.side_effect = bulk_err
+    item_post_mock = mock_erclient_class.return_value.post_sensor_observation
+    item_post_mock.side_effect = [
         async_return(post_sensor_observation_response),
         item_err,
         async_return(post_sensor_observation_response),
@@ -206,5 +211,256 @@ async def test_batch_400_falls_back_to_per_item_and_acks(
     # Must NOT raise: poison items are individually failed, envelope acks
     await process_request(_make_batch_request(mocker, items_count=3))
 
-    assert post_mock.call_count == 4  # 1 bulk + 3 singles
+    assert bulk_post_mock.call_count == 1
+    assert item_post_mock.call_count == 3
     assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 2  # only the two successes cached
+
+
+class _CloseOnceERClient:
+    """Mimics httpx.AsyncClient/erclient's AsyncERClient: once __aexit__ has
+    run on an instance, re-entering it (`async with` again) raises
+    RuntimeError, exactly like httpx 0.24.1's
+    "Cannot reopen a client instance, once it has been closed." This is used
+    to prove C2's fix (a fresh dispatcher/client per chunk and per fallback
+    item) rather than a permissive MagicMock whose no-op __aexit__ hides the
+    reuse-after-close bug entirely.
+    """
+
+    def __init__(self, **kwargs):
+        self.provider_key = kwargs.get("provider_key")
+        self.service_root = "https://fake-site.pamdas.org/api/v1.0"
+        self.username = None
+        self._closed = False
+        self.posted_payloads = []
+
+    async def __aenter__(self):
+        if self._closed:
+            raise RuntimeError("Cannot reopen a client instance, once it has been closed.")
+        return self
+
+    async def __aexit__(self, *args):
+        self._closed = True
+        return False
+
+    def _clean_observation(self, observation):
+        return observation
+
+    async def _post(self, path, payload, params=None):
+        self.posted_payloads.append(payload)
+        return {"result": "ok"}
+
+    async def post_sensor_observation(self, observation, sensor_type="generic"):
+        self.posted_payloads.append(observation)
+        return {"result": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_batch_uses_a_fresh_client_per_chunk(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_pubsub_client,
+):
+    # C2 regression test: a client double that raises if reused after being
+    # closed (like real httpx). A fresh ERObservationsBatchDispatcher (and
+    # thus a fresh client) must be built per chunk, so chunk 2 must succeed
+    # rather than raise RuntimeError on the reused, already-closed client.
+    created_clients = []
+
+    def _make_client(**kwargs):
+        client = _CloseOnceERClient(**kwargs)
+        created_clients.append(client)
+        return client
+
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch(
+        "core.dispatchers.TokenCachingAsyncERClient",
+        mocker.MagicMock(side_effect=_make_client),
+    )
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "ER_BULK_SIZE", 2)
+
+    # 3 items, ER_BULK_SIZE=2 -> 2 chunks (sizes 2 and 1)
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert len(created_clients) == 2
+    all_posted = [item for client in created_clients for item in client.posted_payloads]
+    assert len(all_posted) == 2  # one post per chunk
+    assert sum(len(payload) for payload in all_posted) == 3  # 2 + 1 items total
+    # Every item cached as dispatched proves both chunks succeeded
+    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 3
+
+
+@pytest.mark.asyncio
+async def test_batch_400_fallback_uses_a_fresh_client_per_item(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_pubsub_client,
+):
+    # C2 regression test for the per-item 400 fallback path: each fallback
+    # single-item dispatcher must also get a fresh client, otherwise every
+    # item after the first raises RuntimeError on the closed client and is
+    # wrongly treated as a permanent per-item failure (silent data loss).
+    created_clients = []
+
+    def _make_client(**kwargs):
+        client = _CloseOnceERClient(**kwargs)
+        if not created_clients:
+            # First client (the bulk attempt) fails with a permanent 400.
+            async def _bulk_post(path, payload, params=None):
+                err = ERClientException("ER error ON POST: bad payload")
+                err.status_code = 400
+                raise err
+            client._post = _bulk_post
+        created_clients.append(client)
+        return client
+
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch(
+        "core.dispatchers.TokenCachingAsyncERClient",
+        mocker.MagicMock(side_effect=_make_client),
+    )
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+
+    # Must NOT raise: all 3 items succeed individually after the bulk 400.
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    # 1 client for the failed bulk attempt + 1 fresh client per fallback item
+    assert len(created_clients) == 4
+    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 3
+
+
+@pytest.mark.asyncio
+async def test_batch_all_cached_redelivery_still_publishes_delivered_event(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+    dispatched_event,
+):
+    # I-trace-stamp-loss regression test: if every item in the batch is
+    # already cached as dispatched (e.g. the original attempt died after
+    # caching but before publishing ObservationsBatchDelivered), the
+    # redelivery must still publish the delivered event for all of them -
+    # otherwise the traces never get stamped, even though the data is safely
+    # in ER.
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.return_value = dispatched_event.json()  # every item is a cache hit
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    # No ER post at all - everything was skipped as already delivered.
+    assert not mock_erclient_class.return_value._post.called
+    assert not mock_erclient_class.return_value.post_sensor_observation.called
+    # But the delivered event WAS published, for all 3 gundi_ids.
+    publish_mock = mock_pubsub_client.PublisherClient.return_value.publish
+    assert publish_mock.called
+    (binary_payload,), _ = mock_pubsub_client.PubsubMessage.call_args
+    published_payload = json.loads(binary_payload)
+    assert published_payload["event_type"] == "ObservationsBatchDelivered"
+    assert len(published_payload["payload"]["gundi_ids"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_batch_403_is_treated_as_transient_not_permanent(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # I-403 regression test: a 403 from ER is typically a recoverable
+    # auth/permission condition, not a bad payload. It must be treated like
+    # any other transient error (record distress, publish partial progress,
+    # raise for redelivery) rather than falling back to per-item posts and
+    # permanently failing every item in the chunk.
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    err = ERClientException("ER error ON POST: forbidden")
+    err.status_code = 403
+    mock_erclient_class.return_value._post.side_effect = err
+
+    with pytest.raises(Exception):
+        await process_request(_make_batch_request(mocker, items_count=3))
+
+    # No per-item fallback attempted, nothing cached as delivered
+    assert not mock_erclient_class.return_value.post_sensor_observation.called
+    assert not _dispatched_observation_setex_calls(mock_cache_empty)
+
+
+@pytest.mark.asyncio
+async def test_batch_items_cached_with_batch_ttl_not_single_item_ttl(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # I-cache-TTL regression test: batch-delivered items must be cached with
+    # DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL (>= the 24h PubSub retry
+    # window), not the 1h single-item TTL - otherwise a redelivered envelope
+    # can silently re-post already-delivered items once the cache expires
+    # mid-retry-window.
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    setex_calls = _dispatched_observation_setex_calls(mock_cache_empty)
+    assert len(setex_calls) == 3
+    for call in setex_calls:
+        assert call.kwargs["time"] == settings.DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL
+        assert settings.DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL >= settings.MAX_EVENT_AGE_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_too_old_batch_publishes_dead_lettered_notice(
+    mocker,
+    mock_pubsub_client,
+    mock_publish_event,
+):
+    # I-failure-invisibility regression test: publish_retries_exhausted_event
+    # requires a gundi_id, which batch envelope attributes don't carry, so it
+    # bails out with just a warning log. Without a batch-specific notice, a
+    # batch dying at age-out is completely silent - no activity-log entry
+    # anywhere, even though up to hundreds of observations were dropped.
+    from tests.conftest import _make_request_too_old
+    from gundi_core import events as system_events
+
+    mocker.patch("core.services.pubsub", mock_pubsub_client)
+    # publish_batch_dead_lettered_notice lives in core.event_handlers and
+    # calls the publish_event it imported there - a different name binding
+    # than core.services.publish_event, so it must be patched separately.
+    mocker.patch("core.event_handlers.publish_event", mock_publish_event)
+
+    request = _make_request_too_old(_make_batch_request(mocker, items_count=5))
+    await process_request(request)
+
+    # The envelope was dead-lettered
+    publish_calls = [c for c in mock_pubsub_client.PublisherClient.mock_calls if c[0] == "().publish"]
+    assert len(publish_calls) == 1
+    assert publish_calls[0].args[0] == (
+        f"projects/{settings.GCP_PROJECT_ID}/topics/{settings.OBSERVATIONS_DEAD_LETTER_TOPIC}"
+    )
+    # And a DispatcherCustomLog ERROR notice was published so it's visible
+    # in the portal activity log.
+    assert mock_publish_event.called
+    call_kwargs = mock_publish_event.call_args.kwargs
+    event = call_kwargs["event"]
+    assert isinstance(event, system_events.DispatcherCustomLog)
+    assert event.payload.gundi_id is None
+    assert "batch_count=5" in event.payload.title
+    from gundi_core.schemas.v2 import LogLevel
+    assert event.payload.level == LogLevel.ERROR
+    assert call_kwargs["topic_name"] == settings.DISPATCHER_EVENTS_TOPIC

--- a/tests/test_process_observation_batches_v2.py
+++ b/tests/test_process_observation_batches_v2.py
@@ -1,0 +1,210 @@
+import base64
+import datetime
+import json
+
+import pytest
+
+from core import settings
+from core.services import process_request
+from erclient import ERClientException
+
+
+def _dispatched_observation_setex_calls(mock_cache):
+    # core.utils._cache_db is shared between the dispatched-observation cache
+    # (this helper) and get_integration_details' own config-object cache
+    # (positional-arg `_cache_db.setex(key, ttl, config.json())` call). Filter
+    # to the dispatched-observation writes (kwarg `name="dispatched_observation.*"`)
+    # so assertions about per-item caching aren't thrown off by the unrelated
+    # integration-details cache write that happens once per envelope.
+    return [
+        call for call in mock_cache.setex.call_args_list
+        if call.kwargs.get("name", "").startswith("dispatched_observation.")
+    ]
+
+
+def _make_batch_request(mocker, items_count=3, provider_key="gundi_movebank_abc123"):
+    destination_id = "338225f3-91f9-4fe1-b013-353a229ce504"
+    data_provider_id = "ddd0946d-15b0-4308-b93d-e0470b6d33b6"
+    items = [
+        {
+            "gundi_id": f"23ca4b15-18b6-4cf4-9da6-36dd69c6f63{i}",
+            "observation": {
+                "manufacturer_id": f"device-{i}",
+                "source_type": "tracking-device",
+                "subject_name": f"subject-{i}",
+                "recorded_at": "2026-07-22 11:51:05+00:00",
+                "location": {"lon": -72.7, "lat": -51.6},
+                "additional": {"speed_kmph": 30},
+            },
+        }
+        for i in range(items_count)
+    ]
+    envelope = {
+        "event_id": "48bd073a-8e35-43cf-91c2-c7b4b87a26d7",
+        "timestamp": "2026-07-29 13:23:43.952056+00:00",
+        "schema_version": "v1",
+        "event_type": "ObservationsBatchTransformedER",
+        "payload": {
+            "batch_id": "8a5535df-1b9b-412b-9fd5-e29b09582222",
+            "data_provider_id": data_provider_id,
+            "destination_id": destination_id,
+            "provider_key": provider_key,
+            "items": items,
+        },
+    }
+    publish_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    json_data = {
+        "message": {
+            "data": base64.b64encode(json.dumps(envelope).encode("utf-8")).decode("utf-8"),
+            "attributes": {
+                "gundi_version": "v2",
+                "batch": "true",
+                "batch_count": str(items_count),
+                "provider_key": provider_key,
+                "stream_type": "obv",
+                "destination_id": destination_id,
+                "data_provider_id": data_provider_id,
+                "tracing_context": "{}",
+            },
+            "messageId": "11937923011474847",
+            "message_id": "11937923011474847",
+            "publishTime": publish_time,
+            "publish_time": publish_time,
+        },
+        "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB",
+    }
+    mock_request = mocker.MagicMock()
+    mock_request.headers = {}
+    mock_request.data = json.dumps(json_data)
+    mock_request.get_json.return_value = json_data
+    return mock_request
+
+
+@pytest.mark.asyncio
+async def test_process_observations_batch_posts_one_bulk_request(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    # ONE bulk post for the whole envelope
+    post_mock = mock_erclient_class.return_value.post_sensor_observation
+    assert post_mock.call_count == 1
+    (posted,) = post_mock.call_args.args
+    assert isinstance(posted, list)
+    assert len(posted) == 3
+    # Every item cached as dispatched
+    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 3
+    # One ObservationsBatchDelivered event published
+    publish_mock = mock_pubsub_client.PublisherClient.return_value.publish
+    assert publish_mock.called
+
+
+@pytest.mark.asyncio
+async def test_batch_respects_er_bulk_size(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "ER_BULK_SIZE", 2)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    post_mock = mock_erclient_class.return_value.post_sensor_observation
+    assert post_mock.call_count == 2  # 2 + 1
+
+
+@pytest.mark.asyncio
+async def test_batch_skips_already_delivered_items(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+    dispatched_event,
+):
+    # First item is a cache hit (already delivered); the other two must post.
+    # The leading None accounts for get_integration_details' own cache-miss
+    # read on the shared _cache_db mock, which runs before any per-item check.
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, dispatched_event.json(), None, None)
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    post_mock = mock_erclient_class.return_value.post_sensor_observation
+    (posted,) = post_mock.call_args.args
+    assert len(posted) == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_transient_error_raises_for_redelivery(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    err = ERClientException("ER error ON POST: service unavailable")
+    err.status_code = 503
+    mock_erclient_class.return_value.post_sensor_observation.side_effect = err
+
+    with pytest.raises(Exception):
+        await process_request(_make_batch_request(mocker, items_count=3))
+    # Nothing was cached as delivered
+    assert not _dispatched_observation_setex_calls(mock_cache_empty)
+
+
+@pytest.mark.asyncio
+async def test_batch_400_falls_back_to_per_item_and_acks(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+    post_sensor_observation_response,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+
+    from tests.conftest import async_return
+    bulk_err = ERClientException("ER error ON POST: bad payload")
+    bulk_err.status_code = 400
+    item_err = ERClientException("ER error ON POST: bad payload")
+    item_err.status_code = 400
+    post_mock = mock_erclient_class.return_value.post_sensor_observation
+    # Bulk call fails with 400; per-item fallback: item0 ok, item1 fails, item2 ok
+    post_mock.side_effect = [
+        bulk_err,
+        async_return(post_sensor_observation_response),
+        item_err,
+        async_return(post_sensor_observation_response),
+    ]
+
+    # Must NOT raise: poison items are individually failed, envelope acks
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert post_mock.call_count == 4  # 1 bulk + 3 singles
+    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 2  # only the two successes cached

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -576,10 +576,41 @@ async def test_admission_debits_batch_amount(mock_throttle_db, throttling_enable
 
 
 @pytest.mark.asyncio
-async def test_admission_rejects_batch_over_cap(mock_throttle_db, throttling_enabled, mocker):
-    # Cap is 300/min by default; a second batch pushing the counter to 500 must be deferred
-    mocker.patch.object(settings, "THROTTLE_GRACE_WAIT_MAX_SECONDS", 0)
+async def test_admission_admits_batch_larger_than_cap_when_window_not_full(
+        mock_throttle_db, throttling_enabled
+):
+    # C3 fix: a batch bigger than the whole per-minute cap must still be
+    # admitted as long as the window wasn't already full BEFORE this
+    # increment - otherwise it can NEVER be admitted (count will always land
+    # above the cap) and the envelope starves until it's silently
+    # dead-lettered at the 24h age-out. Cap is 300/min by default; a
+    # 500-item batch against an empty window (prior total 500-500=0 < 300)
+    # must be admitted, even though the post-increment count (500) exceeds
+    # the cap.
     mock_throttle_db.incr.return_value = 500
+    await check_admission(destination_id="dest-1", stream_type="obv", amount=500)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_admission_admits_batch_when_prior_window_had_headroom(
+        mock_throttle_db, throttling_enabled
+):
+    # Cap 300/min; prior total was 50 (count=300, amount=250 -> 300-250=50 <
+    # 300), so this batch is admitted even though the post-increment count
+    # (300) is at the cap.
+    mock_throttle_db.incr.return_value = 300
+    await check_admission(destination_id="dest-1", stream_type="obv", amount=250)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_admission_rejects_batch_when_window_already_full(
+        mock_throttle_db, throttling_enabled, mocker
+):
+    # Cap 300/min; the window was ALREADY at the cap before this increment
+    # (count=550, amount=250 -> prior total 300, not < 300), so this batch
+    # must still be deferred - the cap stays meaningful for a full window.
+    mocker.patch.object(settings, "THROTTLE_GRACE_WAIT_MAX_SECONDS", 0)
+    mock_throttle_db.incr.return_value = 550
     with pytest.raises(ThrottledMessage):
         await check_admission(destination_id="dest-1", stream_type="obv", amount=250)
 
@@ -589,3 +620,21 @@ async def test_admission_default_amount_is_one(mock_throttle_db, throttling_enab
     mock_throttle_db.incr.return_value = 1
     await check_admission(destination_id="dest-1", stream_type="obv")
     assert mock_throttle_db.expire.called  # count == amount == 1 sets the window expiry
+
+
+@pytest.mark.asyncio
+async def test_amount_one_admission_behavior_is_unchanged(
+        mock_throttle_db, throttling_enabled, mocker
+):
+    # count - 1 < cap is equivalent to the old count <= cap for the
+    # classic single-item case: admitted exactly at the cap, rejected just
+    # above it.
+    mocker.patch.object(settings, "THROTTLE_GRACE_WAIT_MAX_SECONDS", 0)
+    cap = settings.DEFAULT_MAX_OBSERVATION_DELIVERIES_PER_MINUTE
+
+    mock_throttle_db.incr.return_value = cap
+    await check_admission(destination_id="dest-1", stream_type="obv", amount=1)  # admitted at the cap
+
+    mock_throttle_db.incr.return_value = cap + 1
+    with pytest.raises(ThrottledMessage):
+        await check_admission(destination_id="dest-1", stream_type="obv", amount=1)  # rejected just above

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -3,7 +3,7 @@ from redis import exceptions as redis_exceptions
 
 from core import settings, throttling
 from core.services import process_request
-from core.throttling import ThrottledMessage
+from core.throttling import ThrottledMessage, check_admission
 import main as main_module
 
 from .conftest import async_return
@@ -562,3 +562,30 @@ async def test_successful_delivery_records_success(
     kwargs = mock_record_success.call_args.kwargs
     assert kwargs["stream_type"] == "ev"
     assert str(kwargs["destination_id"]) == "338225f3-91f9-4fe1-b013-353a229ce504"
+
+
+@pytest.mark.asyncio
+async def test_admission_debits_batch_amount(mock_throttle_db, throttling_enabled):
+    mock_throttle_db.incr.return_value = 250  # first increment of the window, amount=250
+    await check_admission(destination_id="dest-1", stream_type="obv", amount=250)
+    # incr was called with the batch amount
+    args, kwargs = mock_throttle_db.incr.call_args
+    assert 250 in args or kwargs.get("amount") == 250
+    # First increment of the window (count == amount) must still set the expiry
+    assert mock_throttle_db.expire.called
+
+
+@pytest.mark.asyncio
+async def test_admission_rejects_batch_over_cap(mock_throttle_db, throttling_enabled, mocker):
+    # Cap is 300/min by default; a second batch pushing the counter to 500 must be deferred
+    mocker.patch.object(settings, "THROTTLE_GRACE_WAIT_MAX_SECONDS", 0)
+    mock_throttle_db.incr.return_value = 500
+    with pytest.raises(ThrottledMessage):
+        await check_admission(destination_id="dest-1", stream_type="obv", amount=250)
+
+
+@pytest.mark.asyncio
+async def test_admission_default_amount_is_one(mock_throttle_db, throttling_enabled):
+    mock_throttle_db.incr.return_value = 1
+    await check_admission(destination_id="dest-1", stream_type="obv")
+    assert mock_throttle_db.expire.called  # count == amount == 1 sets the window expiry


### PR DESCRIPTION
## Summary

The ER dispatcher can now deliver an entire observation batch envelope with one bulk request per ≤`ER_BULK_SIZE` (default 200) chunk to the sensors endpoint, instead of one Cloud Function invocation + one HTTP request per observation. For a Movebank-scale backfill this removes ~200x request overhead at the ER write path — the slowest stage in the pipeline.

Delivery semantics for envelopes:

- **Idempotent redelivery:** items already recorded in the dispatched-observation cache are skipped up front (cache-only check that never falls back to portal queries), so a nacked envelope re-attempts only what didn't land. A dedicated `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL` (≥ the 24h Pub/Sub retry window) keeps that cache from expiring mid-retry and causing duplicate posts.
- **Transient failures nack the whole envelope; permanent failures shrink it.** ER 5xx/timeouts record distress, report partial progress via `ObservationsBatchDelivered`, and raise so Pub/Sub redelivers. A 400 on a bulk chunk falls back to per-item posts: successes are cached, poison items publish today's per-item `ObservationDeliveryFailed` and are not retried — one bad record can no longer wedge a batch. 403 is deliberately treated as transient (recoverable auth/permission), not permanent data loss.
- **Throttling debits N items per envelope** via the `batch_count` attribute, before parsing. Admission uses had-headroom-before-this-increment semantics so an envelope larger than the per-minute cap still makes progress instead of starving to the 24h age-out.

One workaround worth reviewer attention: erclient 1.16.0's `post_sensor_observation` has a parameter-rebinding bug that posts only the *last* element of a list, so `ERObservationsBatchDispatcher._send` posts the cleaned list via `client._post` directly. Follow-up: fix er-client upstream and drop the workaround. Fresh clients are built per chunk/fallback-item because `async with er_client` permanently closes the underlying http client.

Depends on PADAS/gundi-core#38 (pins `gundi-core==1.13.0`) — **draft until that release is tagged; CI will fail on the pin until then.** Deployment note: this service deploys as one Cloud Function per destination topic — rollout means redeploying all of them, since a stale function dead-letters batch envelopes silently.

Test plan: new suite `tests/test_process_observation_batches_v2.py` (bulk post, sub-chunking, redelivery skip, transient nack, 400 per-item fallback); full suite 182 passed with one pre-existing unrelated local-venv failure (`test_retry_after_from_erclient_drives_cooldown_ttl`, present on the base commit).
