### PR TITLE
fix: shrink batch idempotency cache entries and fix TTL env var

### DIFF
--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -20,6 +20,7 @@ from core.utils import (
     get_integration_details,
     get_dispatched_observation,
     cache_dispatched_observation,
+    mark_observation_dispatched,
     is_observation_dispatched,
     is_null,
     publish_event,
@@ -408,15 +409,9 @@ async def _publish_item_delivery_failed(batch, item, exception):
 
 
 def _cache_item_as_dispatched(batch, item):
-    cache_dispatched_observation(
-        observation=gundi_schemas_v2.DispatchedObservation(
-            gundi_id=item.gundi_id,
-            related_to=None,
-            external_id=None,  # By design: ER bulk responses carry no reliable per-item IDs
-            data_provider_id=batch.data_provider_id,
-            destination_id=batch.destination_id,
-            delivered_at=datetime.now(timezone.utc),
-        ),
+    mark_observation_dispatched(
+        gundi_id=item.gundi_id,
+        destination_id=batch.destination_id,
         # Longer TTL than the single-item path: this cache is what makes
         # envelope redelivery idempotent (see is_observation_dispatched), and
         # PubSub keeps retrying for MAX_EVENT_AGE_SECONDS (24h) - a shorter

--- a/core/settings.py
+++ b/core/settings.py
@@ -51,7 +51,7 @@ ER_TOKEN_CACHE_SECRET = env.str("ER_TOKEN_CACHE_SECRET", "")
 
 # N-seconds to cache portal responses for configuration objects.
 PORTAL_CONFIG_OBJECT_CACHE_TTL = env.int("PORTAL_CONFIG_OBJECT_CACHE_TTL", 60)
-DISPATCHED_OBSERVATIONS_CACHE_TTL = env.int("PORTAL_CONFIG_OBJECT_CACHE_TTL", 60 * 60)  # 1 Hour
+DISPATCHED_OBSERVATIONS_CACHE_TTL = env.int("DISPATCHED_OBSERVATIONS_CACHE_TTL", 60 * 60)  # 1 Hour
 # Idempotency cache for batch-delivered observations. Must exceed the PubSub
 # retry window (24h) so envelope redeliveries keep skipping delivered items.
 DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL = env.int("DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL", 90000)

--- a/core/utils.py
+++ b/core/utils.py
@@ -402,6 +402,30 @@ def cache_dispatched_observation(
         )
 
 
+def mark_observation_dispatched(gundi_id, destination_id, ttl: int):
+    # Batch-path idempotency marker. Writes a 1-byte sentinel under the same
+    # key cache_dispatched_observation uses, so is_observation_dispatched
+    # honors entries written by either path. Batch entries are only ever
+    # existence-checked (ER bulk responses carry no per-item IDs, so there is
+    # no external_id worth storing), and at 24h+ TTLs the full
+    # DispatchedObservation JSON is what fills Redis during large backfills.
+    gundi_id = str(gundi_id)
+    destination_id = str(destination_id)
+    if not gundi_id or not destination_id:
+        return  # Can't build the key
+    try:
+        cache_key = f"dispatched_observation.{gundi_id}.{destination_id}"
+        _cache_db.setex(name=cache_key, time=ttl, value="1")
+    except Exception as e:
+        logger.warning(
+            f"Error writing dispatched-observation marker to Cache: {e}",
+            extra={
+                ExtraKeys.GundiId: gundi_id,
+                ExtraKeys.OutboundIntId: destination_id,
+            },
+        )
+
+
 def is_observation_dispatched(gundi_id, destination_id) -> bool:
     # Cache-only check used by the batch path to skip already-delivered items
     # on envelope redelivery. Unlike get_dispatched_observation, this must NOT

--- a/core/utils.py
+++ b/core/utils.py
@@ -409,10 +409,10 @@ def mark_observation_dispatched(gundi_id, destination_id, ttl: int):
     # existence-checked (ER bulk responses carry no per-item IDs, so there is
     # no external_id worth storing), and at 24h+ TTLs the full
     # DispatchedObservation JSON is what fills Redis during large backfills.
-    gundi_id = str(gundi_id)
-    destination_id = str(destination_id)
     if not gundi_id or not destination_id:
         return  # Can't build the key
+    gundi_id = str(gundi_id)
+    destination_id = str(destination_id)
     try:
         cache_key = f"dispatched_observation.{gundi_id}.{destination_id}"
         _cache_db.setex(name=cache_key, time=ttl, value="1")

--- a/tests/test_process_observation_batches_v2.py
+++ b/tests/test_process_observation_batches_v2.py
@@ -425,6 +425,33 @@ async def test_batch_items_cached_with_batch_ttl_not_single_item_ttl(
 
 
 @pytest.mark.asyncio
+async def test_batch_items_cached_as_sentinel_not_full_observation(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # Memory regression test: at 24h+ TTLs with one key per observation per
+    # destination, this cache dominates Redis during large backfills. Batch
+    # entries are only ever existence-checked (is_observation_dispatched) -
+    # ER bulk responses carry no per-item IDs, so there is no external_id
+    # worth storing - so they must be written as a 1-byte sentinel, not the
+    # full DispatchedObservation JSON.
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    setex_calls = _dispatched_observation_setex_calls(mock_cache_empty)
+    assert len(setex_calls) == 3
+    for call in setex_calls:
+        assert call.kwargs["value"] == "1"
+
+
+@pytest.mark.asyncio
 async def test_too_old_batch_publishes_dead_lettered_notice(
     mocker,
     mock_pubsub_client,


### PR DESCRIPTION
During large provider backfills (currently: Movebank), the dispatched-observation idempotency cache dominates Redis memory: one key per observation per destination, held for 25 hours, each storing a full `DispatchedObservation` JSON that nothing ever reads back — batch entries are only existence-checked on envelope redelivery, since ER bulk responses carry no per-item IDs worth storing. Batch entries are now written as a 1-byte sentinel under the same key format, cutting per-key memory roughly 2–2.5× (key name and Redis overhead dominate the remainder). Old full-JSON entries still count as delivered across the deploy, and the single-item path intentionally keeps the full object: it can carry a real `external_id` and is published in system events.

Separately, the single-item cache TTL was reading the wrong env var (`PORTAL_CONFIG_OBJECT_CACHE_TTL`), so any deployment that sets that var — typically to 60 — has been running the single-item idempotency cache with a 60-second TTL instead of the intended 1 hour, silently re-posting observations on late redeliveries. It now reads its own `DISPATCHED_OBSERVATIONS_CACHE_TTL`. Deploy note: where the old var was set to 60, fixing this grows that key population back to the intended 1-hour window (small next to the batch-key savings).

Validation: new regression test asserts batch delivery writes the sentinel value; observation/batch suites pass (33 tests, including the existing batch-TTL regression test). `tests/test_throttling.py::test_retry_after_from_erclient_drives_cooldown_ttl` fails on `main` too (er-client version mismatch in the test env) and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTKjapakZSvwu8VrxTc9c8
