### PR TITLE
fix: dedup batch redelivery per envelope instead of per observation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,13 +76,26 @@ Deploys a gen2 Cloud Function in `us-central1` triggered by `google.cloud.pubsub
 
 `DispatcherException` and `ReferenceDataError` are re-raised so GCP PubSub retries (function is deployed with `--retry`). The destination portal/EDA is informed via `publish_event()` to `DISPATCHER_EVENTS_TOPIC` for both success and failure paths — this is how the portal's delivery status UI stays up to date.
 
-### Redis usage (`core/utils.py`)
+### Redis usage (`core/utils.py`, `core/batch_progress.py`)
 
 - `_cache_db` wraps a `walrus.Database` (DB `REDIS_DB`, default `3`).
 - Portal config lookups (outbound configs, inbound integrations, v2 Integration details) are cached for `PORTAL_CONFIG_OBJECT_CACHE_TTL` (default 60s).
 - Dispatched v2 observations are cached for `DISPATCHED_OBSERVATIONS_CACHE_TTL` (default 1h) keyed by `gundi_id` + `destination_id` — required for event-update and attachment flows.
 - Cache reads/writes are wrapped in `read_config_from_cache_safe`/`write_config_in_cache_safe` so Redis connection issues log a warning and fall through to the portal API rather than erroring.
 - ER auth tokens from password grants are cached under `er_dispatcher.auth_token.{host}.{username}.{credential-fingerprint}` (fingerprint = `sha256(username:password)[:16]`, so a wrong password is always a cache miss) with TTL matching token expiry (~48h), so dispatch does not perform an OAuth2 grant per message. Entries are Fernet-encrypted under a key derived from the credentials plus the optional `ER_TOKEN_CACHE_SECRET` env var — Redis contents alone can't be read or forged; undecryptable entries are discarded as misses. Static-token integrations bypass this cache.
+- **Batch idempotency** (`core/batch_progress.py`): ONE key per envelope,
+  `batch_progress.{batch_id}.{destination_id}.{sha256(provider_key)[:8]}`, whose
+  value is an 8-byte item-sequence fingerprint followed by a delivered-item
+  bitmap. TTL `DISPATCHED_BATCH_PROGRESS_CACHE_TTL` (90000s) must exceed
+  `MAX_EVENT_AGE_SECONDS`. This replaced one `dispatched_observation.*` key per
+  observation, which filled prod Redis on 2026-08-05 (33.7M keys / 10 GB).
+  `provider_key` is part of the key because cdip-routing groups items per
+  `(destination, effective_provider_key)`.
+- The fingerprint exists because cdip-routing can re-publish the same
+  `batch_id` with a different item list; a mismatch fails open and re-posts.
+- **The single-item path still writes per-observation keys** at
+  `DISPATCHED_OBSERVATIONS_CACHE_TTL` (1h) — `get_dispatched_observation` needs
+  the stored `external_id` to resolve `related_to` for attachments.
 
 ### Tracing
 
@@ -98,6 +111,7 @@ OpenTelemetry tracing is wired in `core/tracing/__init__.py`. When `TRACING_ENAB
 | `core/dispatchers.py` | `ERDispatcher*` classes per stream type; builds `AsyncERClient` from integration config |
 | `core/er_auth.py` | `TokenCachingAsyncERClient` — Redis-cached ER auth tokens, backoff-retried password grants; 401 → invalidate + one retry (see `docs/superpowers/specs/2026-07-27-er-token-caching-design.md`) |
 | `core/utils.py` | Portal API wrappers, Redis caching, `publish_event`, `extract_fields_from_message`, `find_config_for_action` |
+| `core/batch_progress.py` | Per-envelope redelivery-dedup records (pure encode/decode plus never-raising Redis accessors) |
 | `core/settings.py` | All env-var-driven settings, DLQ topic names |
 | `core/tracing/` | OpenTelemetry setup and PubSub trace-context propagation |
 | `tests/conftest.py` | Large shared fixture set — all external services (Gundi portal, PubSub, Redis, ER API) are mocked |
@@ -120,3 +134,5 @@ Tests use `pytest-asyncio` + `pytest-mock`. Structure mirrors the module under t
 | `MAX_EVENT_AGE_SECONDS` | Drop-to-DLQ threshold (default 86400) |
 | `TRACING_ENABLED` / `TRACE_ENVIRONMENT` | OpenTelemetry toggle + env label |
 | `BUCKET_NAME` / `CLOUD_STORAGE_TYPE` | Used by attachment/camera-trap dispatchers to fetch files before POSTing to ER |
+| `DISPATCHED_BATCH_PROGRESS_CACHE_TTL` | Batch dedup record lifetime; must exceed `MAX_EVENT_AGE_SECONDS` (default 90000) |
+| `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED` | Transitional; read legacy per-item keys when an envelope has no progress record (default true) |

--- a/core/batch_progress.py
+++ b/core/batch_progress.py
@@ -1,0 +1,73 @@
+"""Per-envelope redelivery-dedup progress records.
+
+Replaces one Redis key per observation per destination with ONE key per
+envelope: an item-sequence fingerprint plus a bitmap of delivered items. See
+docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md for why the
+fingerprint is load-bearing.
+"""
+import hashlib
+import logging
+
+from core import utils
+
+logger = logging.getLogger(__name__)
+
+KEY_PREFIX = "batch_progress"
+FINGERPRINT_BYTES = 8
+
+
+def progress_key(batch_id, destination_id, provider_key):
+    # provider_key MUST participate: cdip-routing groups transformed items per
+    # (destination, effective_provider_key), so one batch_id + destination_id
+    # legitimately yields several envelopes with disjoint item sets, and
+    # omitting it would collide them onto one record.
+    #
+    # It is hashed rather than embedded because it is free-form and may contain
+    # '.' or ':', which would break prefix-bucketed key analysis (the ops
+    # profiler splits on exactly those) and make the key length unbounded.
+    provider_digest = hashlib.sha256(str(provider_key).encode()).hexdigest()[:8]
+    return f"{KEY_PREFIX}.{batch_id}.{destination_id}.{provider_digest}"
+
+
+def fingerprint(items):
+    """8-byte digest binding a record to an exact ordered item-identity list."""
+    joined = "|".join(str(item.gundi_id) for item in items)
+    return hashlib.sha256(joined.encode()).digest()[:FINGERPRINT_BYTES]
+
+
+def encode(fp, delivered, n):
+    """fingerprint || bitmap, where bit i is set when item i was delivered."""
+    bitmap = bytearray((n + 7) // 8)
+    for index in delivered:
+        if 0 <= index < n:
+            bitmap[index // 8] |= 1 << (index % 8)
+    return bytes(fp) + bytes(bitmap)
+
+
+def decode(raw, expected_fingerprint, n):
+    """Delivered indices, or an empty set when the record is unusable.
+
+    Empty always means "nothing known to be delivered" - a missing record, a
+    truncated value, or a fingerprint mismatch (the envelope was re-published
+    with a different item list, so positional bits no longer refer to the same
+    observations). Callers must treat that as "deliver everything": a duplicate
+    is acceptable, a silently skipped observation is not.
+    """
+    try:
+        if not raw or len(raw) < FINGERPRINT_BYTES:
+            return set()
+        if bytes(raw[:FINGERPRINT_BYTES]) != bytes(expected_fingerprint):
+            return set()
+        bitmap = raw[FINGERPRINT_BYTES:]
+        delivered = set()
+        for index in range(n):
+            byte_index = index // 8
+            if byte_index >= len(bitmap):
+                break  # bitmap shorter than n: the remaining bits are absent
+            if bitmap[byte_index] & (1 << (index % 8)):
+                delivered.add(index)
+        return delivered
+    except (TypeError, ValueError) as e:
+        # A cache returning an unexpected type must fail open, never raise.
+        logger.warning(f"Discarding unusable batch progress record: {type(e).__name__} {e}")
+        return set()

--- a/core/batch_progress.py
+++ b/core/batch_progress.py
@@ -30,9 +30,24 @@ def progress_key(batch_id, destination_id, provider_key):
 
 
 def fingerprint(items):
-    """8-byte digest binding a record to an exact ordered item-identity list."""
-    joined = "|".join(str(item.gundi_id) for item in items)
-    return hashlib.sha256(joined.encode()).digest()[:FINGERPRINT_BYTES]
+    """8-byte digest binding a record to an exact ordered item-identity list.
+
+    Length-prefixed rather than delimiter-joined: `gundi_id` is declared as
+    `Union[UUID, str]` in gundi_core, so arbitrary strings (including ones
+    containing "|") are schema-legal. A delimiter join lets two different
+    item lists collide (e.g. ["a|b", "c"] vs ["a", "b|c"]), and a collision
+    here is not a benign duplicate - it makes decode() report a match against
+    the wrong item list, so a bit gets read as "delivered" for an observation
+    that was never sent. That is the one outcome this design forbids; the
+    length-prefixed encoding is injective, so it cannot happen.
+    """
+    h = hashlib.sha256()
+    h.update(str(len(items)).encode())
+    for item in items:
+        raw = str(item.gundi_id).encode()
+        h.update(len(raw).to_bytes(4, "big"))
+        h.update(raw)
+    return h.digest()[:FINGERPRINT_BYTES]
 
 
 def encode(fp, delivered, n):
@@ -54,6 +69,11 @@ def decode(raw, expected_fingerprint, n):
     is acceptable, a silently skipped observation is not.
     """
     try:
+        if len(expected_fingerprint) != FINGERPRINT_BYTES:
+            # A caller-supplied fingerprint of the wrong length can never
+            # match a validly-encoded record; trusting it anyway risks a
+            # spurious match on truncated/malformed input.
+            return set()
         if not raw or len(raw) < FINGERPRINT_BYTES:
             return set()
         if bytes(raw[:FINGERPRINT_BYTES]) != bytes(expected_fingerprint):
@@ -83,7 +103,7 @@ def read_progress(batch_id, destination_id, provider_key):
     try:
         return utils._cache_db.get(progress_key(batch_id, destination_id, provider_key))
     except Exception as e:
-        logger.warning(f"Error reading batch progress from cache: {e}")
+        logger.warning(f"Error reading batch progress from cache: {e}", exc_info=True)
         return None
 
 
@@ -98,4 +118,4 @@ def write_progress(batch_id, destination_id, provider_key, fp, delivered, n, ttl
             value=encode(fp, delivered, n),
         )
     except Exception as e:
-        logger.warning(f"Error writing batch progress to cache: {e}")
+        logger.warning(f"Error writing batch progress to cache: {e}", exc_info=True)

--- a/core/batch_progress.py
+++ b/core/batch_progress.py
@@ -71,3 +71,31 @@ def decode(raw, expected_fingerprint, n):
         # A cache returning an unexpected type must fail open, never raise.
         logger.warning(f"Discarding unusable batch progress record: {type(e).__name__} {e}")
         return set()
+
+
+def read_progress(batch_id, destination_id, provider_key):
+    """Raw record bytes, or None. Never raises.
+
+    Reads utils._cache_db at call time (not via a module-level import) so the
+    test suite's `mocker.patch("core.utils._cache_db", ...)` takes effect -
+    same pattern as core/throttling.py.
+    """
+    try:
+        return utils._cache_db.get(progress_key(batch_id, destination_id, provider_key))
+    except Exception as e:
+        logger.warning(f"Error reading batch progress from cache: {e}")
+        return None
+
+
+def write_progress(batch_id, destination_id, provider_key, fp, delivered, n, ttl):
+    """Persist the record. No-op when nothing was delivered. Never raises."""
+    if not delivered:
+        return
+    try:
+        utils._cache_db.setex(
+            name=progress_key(batch_id, destination_id, provider_key),
+            time=ttl,
+            value=encode(fp, delivered, n),
+        )
+    except Exception as e:
+        logger.warning(f"Error writing batch progress to cache: {e}")

--- a/core/batch_progress.py
+++ b/core/batch_progress.py
@@ -40,9 +40,14 @@ def fingerprint(items):
     the wrong item list, so a bit gets read as "delivered" for an observation
     that was never sent. That is the one outcome this design forbids; the
     length-prefixed encoding is injective, so it cannot happen.
+
+    Every length is fixed-width (4-byte big-endian), including the leading item
+    count. A decimal count would itself be variable-length, which would leave
+    the encoding injective only under a side argument about how large a single
+    `gundi_id` can get; fixed-width makes it unconditional.
     """
     h = hashlib.sha256()
-    h.update(str(len(items)).encode())
+    h.update(len(items).to_bytes(4, "big"))
     for item in items:
         raw = str(item.gundi_id).encode()
         h.update(len(raw).to_bytes(4, "big"))

--- a/core/batch_progress.py
+++ b/core/batch_progress.py
@@ -38,13 +38,23 @@ def fingerprint(items):
     item lists collide (e.g. ["a|b", "c"] vs ["a", "b|c"]), and a collision
     here is not a benign duplicate - it makes decode() report a match against
     the wrong item list, so a bit gets read as "delivered" for an observation
-    that was never sent. That is the one outcome this design forbids; the
-    length-prefixed encoding is injective, so it cannot happen.
+    that was never sent. That is the one outcome this design forbids, so the
+    encoding is built to be injective: no two different ordered id sequences
+    produce the same bytes to hash.
 
     Every length is fixed-width (4-byte big-endian), including the leading item
     count. A decimal count would itself be variable-length, which would leave
     the encoding injective only under a side argument about how large a single
     `gundi_id` can get; fixed-width makes it unconditional.
+
+    Injective *encoding* is not a collision-free *digest* — this truncates
+    SHA-256 to 8 bytes, so two distinct inputs can still collide at ~2^-64.
+    What makes that acceptable is scope: a fingerprint is only ever compared
+    against records under the same `(batch_id, destination_id, provider_key)`
+    key, and only a handful of item lists ever exist for one key within its 25h
+    lifetime. So the exposure is ~2^-64 per comparison, not a birthday problem
+    across every envelope in the system. Widen FINGERPRINT_BYTES if that
+    scoping assumption ever stops holding.
     """
     h = hashlib.sha256()
     h.update(len(items).to_bytes(4, "big"))

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -456,14 +456,20 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
             raise ReferenceDataError(error_msg)
 
         fp = batch_progress.fingerprint(batch.items)
-        delivered = batch_progress.decode(
-            batch_progress.read_progress(
-                batch.batch_id, destination_id, batch.provider_key
-            ),
-            fp,
-            len(batch.items),
-        )
-        dedup_source = "batch_progress" if delivered else "none"
+        raw = batch_progress.read_progress(batch.batch_id, destination_id, batch.provider_key)
+        delivered = batch_progress.decode(raw, fp, len(batch.items))
+        if delivered:
+            dedup_source = "batch_progress"
+        elif raw:
+            # A record was present but decode() couldn't use it - a
+            # fingerprint mismatch (envelope re-published with a different
+            # item list) or a truncated value. This is the one condition
+            # that causes a full-envelope duplicate re-post, so it gets its
+            # own telemetry value instead of being indistinguishable from a
+            # normal first delivery ("none").
+            dedup_source = "unusable_record"
+        else:
+            dedup_source = "none"
         if not delivered and settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED:
             legacy = _legacy_delivered_indices(batch, destination_id)
             if legacy:

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -13,14 +13,13 @@ from gundi_core.events.transformers import (
 # NOTE: ObservationsBatchTransformedER lives in gundi_core.events.batches, not
 # .transformers (verified against gundi_core 1.13.0's actual module layout).
 from gundi_core.events import ObservationsBatchTransformedER
-from core import tracing, dispatchers, settings, throttling
+from core import tracing, dispatchers, settings, throttling, batch_progress
 from core.errors import ReferenceDataError, DispatcherException
 from core.utils import (
     ExtraKeys,
     get_integration_details,
     get_dispatched_observation,
     cache_dispatched_observation,
-    mark_observation_dispatched,
     is_observation_dispatched,
     is_null,
     publish_event,
@@ -408,17 +407,31 @@ async def _publish_item_delivery_failed(batch, item, exception):
     )
 
 
-def _cache_item_as_dispatched(batch, item):
-    mark_observation_dispatched(
-        gundi_id=item.gundi_id,
-        destination_id=batch.destination_id,
-        # Longer TTL than the single-item path: this cache is what makes
-        # envelope redelivery idempotent (see is_observation_dispatched), and
-        # PubSub keeps retrying for MAX_EVENT_AGE_SECONDS (24h) - a shorter
-        # TTL would silently expire the skip-cache mid-retry-window and
-        # re-post already-delivered items as duplicates.
-        ttl=settings.DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL,
+def _flush_progress(batch, destination_id, fp, delivered):
+    # One write per chunk, not per item. Called after every successful chunk so
+    # progress is durable BEFORE the transient-error branch raises to nack.
+    batch_progress.write_progress(
+        batch_id=batch.batch_id,
+        destination_id=destination_id,
+        provider_key=batch.provider_key,
+        fp=fp,
+        delivered=delivered,
+        n=len(batch.items),
+        ttl=settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL,
     )
+
+
+def _legacy_delivered_indices(batch, destination_id):
+    # Transitional: envelopes in flight when the progress record shipped carry
+    # per-item dispatched_observation keys instead. Reading them for one 25h
+    # window (> MAX_EVENT_AGE_SECONDS) keeps the deploy from re-posting
+    # everything already delivered. Deleted with the flag.
+    return {
+        index for index, item in enumerate(batch.items)
+        if is_observation_dispatched(
+            gundi_id=str(item.gundi_id), destination_id=destination_id
+        )
+    }
 
 
 async def dispatch_observations_batch_v2(batch, attributes: dict):
@@ -431,16 +444,37 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
         current_span.set_attribute("destination_id", destination_id)
         current_span.set_attribute("batch_count", len(batch.items))
 
+        if not batch.items:
+            # Empty batches are valid to parse and are a no-op by contract
+            # (see gundi_core/events/batches.py).
+            return
+
         destination_integration = await get_integration_details(integration_id=destination_id)
         if not destination_integration:
             error_msg = f"No destination config details found for destination_id {destination_id}"
             logger.error(error_msg)
             raise ReferenceDataError(error_msg)
 
+        fp = batch_progress.fingerprint(batch.items)
+        delivered = batch_progress.decode(
+            batch_progress.read_progress(
+                batch.batch_id, destination_id, batch.provider_key
+            ),
+            fp,
+            len(batch.items),
+        )
+        dedup_source = "batch_progress" if delivered else "none"
+        if not delivered and settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED:
+            legacy = _legacy_delivered_indices(batch, destination_id)
+            if legacy:
+                delivered = legacy
+                dedup_source = "legacy"
+        current_span.set_attribute("dedup_source", dedup_source)
+
         # Skip items already delivered — makes envelope redelivery idempotent
         pending = [
-            item for item in batch.items
-            if not is_observation_dispatched(gundi_id=str(item.gundi_id), destination_id=destination_id)
+            (index, item) for index, item in enumerate(batch.items)
+            if index not in delivered
         ]
         current_span.set_attribute("pending_count", len(pending))
         if not pending:
@@ -465,7 +499,7 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                 provider=batch.provider_key,
             )
             try:
-                await dispatcher.send([item.observation for item in chunk])
+                await dispatcher.send([item.observation for _, item in chunk])
             except Exception as e:
                 status_code = getattr(e, "status_code", None)
                 error = f"{type(e).__name__}: {e}"
@@ -477,7 +511,7 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                         f"Falling back to per-item posts for {len(chunk)} items."
                     )
                     fallback_delivered_any = False
-                    for item in chunk:
+                    for index, item in chunk:
                         # Fresh client per item too, for the same reason as
                         # above (each single_dispatcher.send closes its client).
                         single_dispatcher = dispatchers.ERObservationDispatcher(
@@ -492,9 +526,10 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                             )
                             await _publish_item_delivery_failed(batch, item, item_exc)
                         else:
-                            _cache_item_as_dispatched(batch, item)
+                            delivered.add(index)
                             delivered_gundi_ids.append(str(item.gundi_id))
                             fallback_delivered_any = True
+                    _flush_progress(batch, destination_id, fp, delivered)
                     if fallback_delivered_any:
                         # A successful fallback delivery proves the site is
                         # reachable, same as a successful bulk chunk — clear
@@ -521,9 +556,10 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                         f"Transient error dispatching batch {batch.batch_id}: {error}"
                     )
             else:
-                for item in chunk:
-                    _cache_item_as_dispatched(batch, item)
+                for index, item in chunk:
+                    delivered.add(index)
                     delivered_gundi_ids.append(str(item.gundi_id))
+                _flush_progress(batch, destination_id, fp, delivered)
                 throttling.record_success(destination_id=destination_id, stream_type=stream_type)
 
         current_span.set_attribute("delivered_count", len(delivered_gundi_ids))

--- a/core/event_handlers.py
+++ b/core/event_handlers.py
@@ -493,6 +493,18 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
             await _publish_batch_delivered(batch, [str(item.gundi_id) for item in batch.items])
             return
 
+        # Items a PREVIOUS attempt delivered (from the progress record or the
+        # legacy keys). Every publish below has to cover these too, not just
+        # this attempt's: an attempt that flushed progress and then died before
+        # publishing would otherwise leave their traces unstamped forever —
+        # exactly the loss the all-delivered branch above exists to prevent,
+        # only in the partial case. The portal handler is idempotent against
+        # repeat events, so re-reporting them is free.
+        already_delivered_gundi_ids = [
+            str(batch.items[index].gundi_id) for index in sorted(delivered)
+        ]
+        # Delivered by THIS attempt — kept separate so the delivered_count span
+        # attribute keeps meaning "what this invocation sent".
         delivered_gundi_ids = []
         for chunk in _chunked(pending, settings.ER_BULK_SIZE):
             # A fresh dispatcher (and so a fresh underlying http client) per
@@ -557,7 +569,9 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                     )
                     if notify_scope:
                         await publish_throttling_notice(attributes=attributes, scope=notify_scope)
-                    await _publish_batch_delivered(batch, delivered_gundi_ids)
+                    await _publish_batch_delivered(
+                        batch, already_delivered_gundi_ids + delivered_gundi_ids
+                    )
                     raise DispatcherException(
                         f"Transient error dispatching batch {batch.batch_id}: {error}"
                     )
@@ -569,7 +583,9 @@ async def dispatch_observations_batch_v2(batch, attributes: dict):
                 throttling.record_success(destination_id=destination_id, stream_type=stream_type)
 
         current_span.set_attribute("delivered_count", len(delivered_gundi_ids))
-        await _publish_batch_delivered(batch, delivered_gundi_ids)
+        await _publish_batch_delivered(
+            batch, already_delivered_gundi_ids + delivered_gundi_ids
+        )
 
 
 async def handle_er_observations_batch(event: ObservationsBatchTransformedER, attributes: dict):

--- a/core/settings.py
+++ b/core/settings.py
@@ -55,6 +55,17 @@ DISPATCHED_OBSERVATIONS_CACHE_TTL = env.int("DISPATCHED_OBSERVATIONS_CACHE_TTL",
 # Idempotency cache for batch-delivered observations. Must exceed the PubSub
 # retry window (24h) so envelope redeliveries keep skipping delivered items.
 DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL = env.int("DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL", 90000)
+# Idempotency record for batch-delivered observations: ONE key per envelope
+# holding an item-sequence fingerprint plus a delivered-item bitmap. Must
+# exceed the PubSub retry window (MAX_EVENT_AGE_SECONDS, 86400 in prod) so
+# envelope redeliveries keep skipping delivered items. Replaces the per-item
+# dispatched_observation keys that filled prod Redis on 2026-08-05.
+DISPATCHED_BATCH_PROGRESS_CACHE_TTL = env.int("DISPATCHED_BATCH_PROGRESS_CACHE_TTL", 90000)
+# Transitional: when an envelope has no progress record, fall back to reading
+# the legacy per-item dispatched_observation keys. Stops the deploy from
+# re-posting everything already delivered for envelopes in flight at rollout.
+# Set false >=25h after deploy, then delete the fallback (see the design doc).
+BATCH_DEDUP_LEGACY_FALLBACK_ENABLED = env.bool("BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", True)
 
 # Used in OTel traces/spans to set the 'environment' attribute, used on metrics calculation
 TRACE_ENVIRONMENT = env.str("TRACE_ENVIRONMENT", "dev")

--- a/docs/rollout-envelope-dedup.md
+++ b/docs/rollout-envelope-dedup.md
@@ -15,7 +15,7 @@ legacy fallback and recreates the duplicate burst it exists to prevent.
 4. **Set `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=false`** and redeploy. Confirm
    `dedup_source` is never `legacy`.
 5. **Optionally purge leftovers.** `dispatched_observation.*` keys expire on
-   their own within 25h of their last write; `scripts/redis_stale_key_cleaner.py`
+   their own within 25h of their last write; `cdip_admin/scripts/redis_stale_key_cleaner.py`
    in the `cdip` repo (branch `backup/redis-prod-cleanup-prerebase`) can UNLINK
    them sooner.
 6. **Scale Redis back down** once db3 is at its new steady state (~0.1-0.2 GB).
@@ -31,5 +31,7 @@ route and `CONFIG GET` is disabled):
     kubectl --context gundi-prod -n application exec -i <admin-portal-pod> \
       -c admin-portal -- python3 - < script.py
 
-db3 is the ER dispatcher's keyspace. Expect `batch_progress.*` to dominate and
-`dispatched_observation.*` to shrink to zero over 25h.
+db3 is the ER dispatcher's keyspace. Expect `batch_progress.*` to dominate, and
+`dispatched_observation.*` to shrink to a small steady-state baseline — the
+still-active single-item path writes that same key prefix at a 1h TTL — as the
+legacy batch markers age out.

--- a/docs/rollout-envelope-dedup.md
+++ b/docs/rollout-envelope-dedup.md
@@ -1,0 +1,35 @@
+# Rollout: envelope-scoped batch dedup
+
+Ordering matters. Purging `dispatched_observation.*` before step 4 breaks the
+legacy fallback and recreates the duplicate burst it exists to prevent.
+
+1. **Scale prod Redis up.** Independent of this change and more urgent:
+   `sintegrate-4bb07e9c` (project `cdip-prod1-78ca`, region `us-central1`) is a
+   10 GB instance that hit 100%. Size for peak observation rate x 25h until this
+   ships, then it can come back down.
+2. **Deploy** with `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=true` (the default).
+   Confirm in traces that `dedup_source` is `batch_progress` for new envelopes
+   and `legacy` for in-flight ones.
+3. **Wait at least 25h** — longer than `MAX_EVENT_AGE_SECONDS` (86400), so no
+   envelope predating the deploy can still be redelivered.
+4. **Set `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=false`** and redeploy. Confirm
+   `dedup_source` is never `legacy`.
+5. **Optionally purge leftovers.** `dispatched_observation.*` keys expire on
+   their own within 25h of their last write; `scripts/redis_stale_key_cleaner.py`
+   in the `cdip` repo (branch `backup/redis-prod-cleanup-prerebase`) can UNLINK
+   them sooner.
+6. **Scale Redis back down** once db3 is at its new steady state (~0.1-0.2 GB).
+7. **Follow-up PR:** delete `_legacy_delivered_indices`,
+   `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED`, `utils.mark_observation_dispatched`,
+   and `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL`.
+
+## Verifying in prod
+
+Profile the keyspace read-only from a portal pod (Memorystore has no public
+route and `CONFIG GET` is disabled):
+
+    kubectl --context gundi-prod -n application exec -i <admin-portal-pod> \
+      -c admin-portal -- python3 - < script.py
+
+db3 is the ER dispatcher's keyspace. Expect `batch_progress.*` to dominate and
+`dispatched_observation.*` to shrink to zero over 25h.

--- a/docs/rollout-envelope-dedup.md
+++ b/docs/rollout-envelope-dedup.md
@@ -8,8 +8,16 @@ legacy fallback and recreates the duplicate burst it exists to prevent.
    10 GB instance that hit 100%. Size for peak observation rate x 25h until this
    ships, then it can come back down.
 2. **Deploy** with `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=true` (the default).
-   Confirm in traces that `dedup_source` is `batch_progress` for new envelopes
-   and `legacy` for in-flight ones.
+   Check `dedup_source` in traces, but expect `none` to dominate — a brand-new
+   envelope's *first* delivery has no progress record yet, so `none` is the
+   healthy steady-state value, not a sign of failure. `batch_progress` appears
+   only on redelivery of an envelope that already flushed progress once, and
+   `unusable_record` only on a fingerprint mismatch or truncated record (rare;
+   worth investigating if it is not). `legacy` should appear only for
+   envelopes published before the deploy. The signal that actually matters
+   here is **`legacy` decaying to zero over the 25h window** — that is what
+   confirms every pre-deploy envelope has drained, not the presence of
+   `batch_progress`.
 3. **Wait at least 25h** — longer than `MAX_EVENT_AGE_SECONDS` (86400), so no
    envelope predating the deploy can still be redelivered.
 4. **Set `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=false`** and redeploy. Confirm

--- a/docs/superpowers/plans/2026-08-05-envelope-scoped-batch-dedup.md
+++ b/docs/superpowers/plans/2026-08-05-envelope-scoped-batch-dedup.md
@@ -1,0 +1,968 @@
+# Envelope-Scoped Batch Redelivery Dedup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the batch path's one-Redis-key-per-observation idempotency cache with one per-envelope progress record, cutting projected steady-state Redis usage from ~9.4 GB to ~0.1-0.2 GB.
+
+**Architecture:** A new `core/batch_progress.py` module stores, per envelope, a single Redis string keyed on `(batch_id, destination_id, sha256(provider_key)[:8])`. Its value is an 8-byte fingerprint of the item-identity sequence followed by a bitmap whose bit `i` marks `batch.items[i]` as delivered. `dispatch_observations_batch_v2` reads that record once instead of doing N `GET`s, and flushes it once per chunk instead of doing N `SETEX`s. A transitional dual-read fallback to the legacy per-item keys prevents a duplicate burst from envelopes in flight at deploy time.
+
+**Tech Stack:** Python 3.10, `redis`/`walrus` via `core.utils._cache_db`, pytest 7.2.1 + pytest-asyncio 0.20.3 + pytest-mock 3.10.0, OpenTelemetry spans.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md`
+
+## Global Constraints
+
+- Every function in `core/batch_progress.py` must **never raise**. The dedup layer failing must never stall delivery. On any error, behave as "nothing known to be delivered".
+- Duplicates are the accepted failure currency; a **skipped (never-delivered) observation is never acceptable**. Every ambiguous case fails open toward re-posting.
+- `DISPATCHED_BATCH_PROGRESS_CACHE_TTL` default is `90000` and must exceed `MAX_EVENT_AGE_SECONDS` (86400 in prod).
+- Access the Redis client as `utils._cache_db` **at call time**, never `from core.utils import _cache_db`. The test suite patches `core.utils._cache_db`, so an import-time binding would silently bypass the mock. `core/throttling.py` sets this precedent (`db = utils._cache_db` inside each function).
+- Do **not** touch the single-item path. `cache_dispatched_observation`, `get_dispatched_observation`, and the 1h `DISPATCHED_OBSERVATIONS_CACHE_TTL` stay exactly as they are — `get_dispatched_observation` supplies `external_id` for `related_to` attachment delivery.
+- There is **no `fakeredis`** in this repo. Redis is mocked with `MagicMock` via the `mock_cache_*` fixtures in `tests/conftest.py`.
+- `core.utils._cache_db` is **one shared mock** serving both `get_integration_details`' config-object cache and the dedup cache. Any test using `get.side_effect` must account for the config-cache read that happens **first**, once per envelope.
+- Call `_cache_db.setex` with keyword arguments (`name=`, `time=`, `value=`) so tests can filter calls by `call.kwargs["name"]` prefix.
+
+---
+
+### Task 1: Pure progress-record encoding in `core/batch_progress.py`
+
+Key construction, fingerprinting, and bitmap encode/decode. All pure functions — no Redis, no mocking needed. This is where the correctness-critical fail-open logic lives.
+
+**Files:**
+- Create: `core/batch_progress.py`
+- Test: `tests/test_batch_progress.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `progress_key(batch_id, destination_id, provider_key) -> str`
+  - `fingerprint(items) -> bytes` (8 bytes; `items` is any sequence of objects with a `.gundi_id` attribute)
+  - `encode(fp: bytes, delivered: set[int], n: int) -> bytes`
+  - `decode(raw: bytes | None, expected_fingerprint: bytes, n: int) -> set[int]`
+  - Module constants `KEY_PREFIX = "batch_progress"`, `FINGERPRINT_BYTES = 8`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_batch_progress.py`:
+
+```python
+from types import SimpleNamespace
+
+from core import batch_progress
+
+
+def _items(*gundi_ids):
+    return [SimpleNamespace(gundi_id=g) for g in gundi_ids]
+
+
+def test_progress_key_hashes_provider_key_and_is_delimiter_safe():
+    key = batch_progress.progress_key(
+        "8a5535df-1b9b-412b-9fd5-e29b09582222",
+        "338225f3-91f9-4fe1-b013-353a229ce504",
+        "gundi.movebank:abc123",  # contains BOTH separators
+    )
+    assert key.startswith("batch_progress.8a5535df-1b9b-412b-9fd5-e29b09582222.")
+    # 4 segments exactly: prefix, batch_id, destination_id, provider digest
+    assert len(key.split(".")) == 4
+    assert "movebank" not in key  # provider_key never appears literally
+
+
+def test_progress_key_differs_per_provider_key():
+    args = ("batch-1", "dest-1")
+    assert batch_progress.progress_key(*args, "key-a") != batch_progress.progress_key(*args, "key-b")
+
+
+def test_fingerprint_is_stable_and_order_sensitive():
+    a = batch_progress.fingerprint(_items("id-0", "id-1", "id-2"))
+    assert a == batch_progress.fingerprint(_items("id-0", "id-1", "id-2"))
+    assert len(a) == 8
+    assert a != batch_progress.fingerprint(_items("id-2", "id-1", "id-0"))  # reorder
+    assert a != batch_progress.fingerprint(_items("id-0", "id-1"))          # removed
+    assert a != batch_progress.fingerprint(_items("id-0", "id-1", "id-2", "id-3"))  # added
+
+
+def test_encode_sets_expected_bits():
+    fp = b"\x00" * 8
+    assert batch_progress.encode(fp, {0, 1, 2}, 3)[8:] == bytes([0b00000111])
+    assert batch_progress.encode(fp, {0, 2}, 3)[8:] == bytes([0b00000101])
+    assert batch_progress.encode(fp, {8}, 9)[8:] == bytes([0b00000000, 0b00000001])
+
+
+def test_encode_ignores_out_of_range_indices():
+    fp = b"\x00" * 8
+    assert batch_progress.encode(fp, {-1, 5, 99}, 3)[8:] == bytes([0b00000000])
+
+
+def test_encode_decode_round_trips_across_byte_boundaries():
+    for n in (0, 1, 7, 8, 9, 200):
+        items = _items(*[f"id-{i}" for i in range(n)])
+        fp = batch_progress.fingerprint(items)
+        delivered = set(range(0, n, 3))
+        raw = batch_progress.encode(fp, delivered, n)
+        assert batch_progress.decode(raw, fp, n) == delivered
+
+
+def test_decode_returns_empty_when_record_missing_or_truncated():
+    fp = b"\x01" * 8
+    assert batch_progress.decode(None, fp, 3) == set()
+    assert batch_progress.decode(b"", fp, 3) == set()
+    assert batch_progress.decode(b"\x01" * 7, fp, 3) == set()  # shorter than fingerprint
+
+
+def test_decode_returns_empty_on_fingerprint_mismatch():
+    # The envelope was re-published with a different item list, so positional
+    # bits no longer refer to the same observations. Must fail open.
+    items = _items("id-0", "id-1", "id-2")
+    raw = batch_progress.encode(batch_progress.fingerprint(items), {0, 1, 2}, 3)
+    other = batch_progress.fingerprint(_items("id-9", "id-8", "id-7"))
+    assert batch_progress.decode(raw, other, 3) == set()
+
+
+def test_decode_treats_short_bitmap_as_absent_bits():
+    fp = b"\x02" * 8
+    raw = fp + bytes([0b00000101])  # only 1 byte of bitmap, but n spans 2
+    assert batch_progress.decode(raw, fp, 12) == {0, 2}
+
+
+def test_decode_ignores_extra_bitmap_bytes_beyond_n():
+    fp = b"\x03" * 8
+    raw = fp + bytes([0b11111111, 0b11111111])
+    assert batch_progress.decode(raw, fp, 3) == {0, 1, 2}
+
+
+def test_decode_returns_empty_for_non_bytes_value():
+    # A cache returning a str (or anything unexpected) must fail open, not raise.
+    fp = b"\x04" * 8
+    assert batch_progress.decode("not-bytes", fp, 3) == set()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_batch_progress.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'core.batch_progress'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `core/batch_progress.py`:
+
+```python
+"""Per-envelope redelivery-dedup progress records.
+
+Replaces one Redis key per observation per destination with ONE key per
+envelope: an item-sequence fingerprint plus a bitmap of delivered items. See
+docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md for why the
+fingerprint is load-bearing.
+"""
+import hashlib
+import logging
+
+from core import utils
+
+logger = logging.getLogger(__name__)
+
+KEY_PREFIX = "batch_progress"
+FINGERPRINT_BYTES = 8
+
+
+def progress_key(batch_id, destination_id, provider_key):
+    # provider_key MUST participate: cdip-routing groups transformed items per
+    # (destination, effective_provider_key), so one batch_id + destination_id
+    # legitimately yields several envelopes with disjoint item sets, and
+    # omitting it would collide them onto one record.
+    #
+    # It is hashed rather than embedded because it is free-form and may contain
+    # '.' or ':', which would break prefix-bucketed key analysis (the ops
+    # profiler splits on exactly those) and make the key length unbounded.
+    provider_digest = hashlib.sha256(str(provider_key).encode()).hexdigest()[:8]
+    return f"{KEY_PREFIX}.{batch_id}.{destination_id}.{provider_digest}"
+
+
+def fingerprint(items):
+    """8-byte digest binding a record to an exact ordered item-identity list."""
+    joined = "|".join(str(item.gundi_id) for item in items)
+    return hashlib.sha256(joined.encode()).digest()[:FINGERPRINT_BYTES]
+
+
+def encode(fp, delivered, n):
+    """fingerprint || bitmap, where bit i is set when item i was delivered."""
+    bitmap = bytearray((n + 7) // 8)
+    for index in delivered:
+        if 0 <= index < n:
+            bitmap[index // 8] |= 1 << (index % 8)
+    return bytes(fp) + bytes(bitmap)
+
+
+def decode(raw, expected_fingerprint, n):
+    """Delivered indices, or an empty set when the record is unusable.
+
+    Empty always means "nothing known to be delivered" - a missing record, a
+    truncated value, or a fingerprint mismatch (the envelope was re-published
+    with a different item list, so positional bits no longer refer to the same
+    observations). Callers must treat that as "deliver everything": a duplicate
+    is acceptable, a silently skipped observation is not.
+    """
+    try:
+        if not raw or len(raw) < FINGERPRINT_BYTES:
+            return set()
+        if bytes(raw[:FINGERPRINT_BYTES]) != bytes(expected_fingerprint):
+            return set()
+        bitmap = raw[FINGERPRINT_BYTES:]
+        delivered = set()
+        for index in range(n):
+            byte_index = index // 8
+            if byte_index >= len(bitmap):
+                break  # bitmap shorter than n: the remaining bits are absent
+            if bitmap[byte_index] & (1 << (index % 8)):
+                delivered.add(index)
+        return delivered
+    except (TypeError, ValueError) as e:
+        # A cache returning an unexpected type must fail open, never raise.
+        logger.warning(f"Discarding unusable batch progress record: {type(e).__name__} {e}")
+        return set()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_batch_progress.py -v`
+Expected: PASS (12 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/batch_progress.py tests/test_batch_progress.py
+git commit -m "feat: add per-envelope batch progress record encoding"
+```
+
+---
+
+### Task 2: Redis read/write wrappers
+
+Thin, never-raising accessors around the shared cache client.
+
+**Files:**
+- Modify: `core/batch_progress.py` (append)
+- Test: `tests/test_batch_progress.py` (append)
+
+**Interfaces:**
+- Consumes: `progress_key`, `encode` from Task 1.
+- Produces:
+  - `read_progress(batch_id, destination_id, provider_key) -> bytes | None`
+  - `write_progress(batch_id, destination_id, provider_key, fp, delivered, n, ttl) -> None`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_batch_progress.py`:
+
+```python
+def test_read_progress_returns_cached_value(mocker):
+    db = mocker.MagicMock()
+    db.get.return_value = b"payload"
+    mocker.patch("core.utils._cache_db", db)
+
+    assert batch_progress.read_progress("b1", "d1", "pk") == b"payload"
+    db.get.assert_called_once_with(batch_progress.progress_key("b1", "d1", "pk"))
+
+
+def test_read_progress_returns_none_on_redis_error(mocker):
+    db = mocker.MagicMock()
+    db.get.side_effect = RuntimeError("redis down")
+    mocker.patch("core.utils._cache_db", db)
+
+    assert batch_progress.read_progress("b1", "d1", "pk") is None
+
+
+def test_write_progress_stores_encoded_record_with_ttl(mocker):
+    db = mocker.MagicMock()
+    mocker.patch("core.utils._cache_db", db)
+    fp = batch_progress.fingerprint(_items("id-0", "id-1", "id-2"))
+
+    batch_progress.write_progress("b1", "d1", "pk", fp, {0, 2}, 3, ttl=90000)
+
+    db.setex.assert_called_once_with(
+        name=batch_progress.progress_key("b1", "d1", "pk"),
+        time=90000,
+        value=fp + bytes([0b00000101]),
+    )
+
+
+def test_write_progress_is_a_noop_when_nothing_delivered(mocker):
+    # An all-zero record is indistinguishable from a missing one, so never
+    # write it - that keeps decode's empty-set result unambiguous.
+    db = mocker.MagicMock()
+    mocker.patch("core.utils._cache_db", db)
+
+    batch_progress.write_progress("b1", "d1", "pk", b"\x00" * 8, set(), 3, ttl=90000)
+
+    assert not db.setex.called
+
+
+def test_write_progress_swallows_redis_error(mocker):
+    db = mocker.MagicMock()
+    db.setex.side_effect = RuntimeError("redis down")
+    mocker.patch("core.utils._cache_db", db)
+
+    batch_progress.write_progress("b1", "d1", "pk", b"\x00" * 8, {0}, 3, ttl=90000)  # must not raise
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_batch_progress.py -k "read_progress or write_progress" -v`
+Expected: FAIL with `AttributeError: module 'core.batch_progress' has no attribute 'read_progress'`
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `core/batch_progress.py`:
+
+```python
+def read_progress(batch_id, destination_id, provider_key):
+    """Raw record bytes, or None. Never raises.
+
+    Reads utils._cache_db at call time (not via a module-level import) so the
+    test suite's `mocker.patch("core.utils._cache_db", ...)` takes effect -
+    same pattern as core/throttling.py.
+    """
+    try:
+        return utils._cache_db.get(progress_key(batch_id, destination_id, provider_key))
+    except Exception as e:
+        logger.warning(f"Error reading batch progress from cache: {e}")
+        return None
+
+
+def write_progress(batch_id, destination_id, provider_key, fp, delivered, n, ttl):
+    """Persist the record. No-op when nothing was delivered. Never raises."""
+    if not delivered:
+        return
+    try:
+        utils._cache_db.setex(
+            name=progress_key(batch_id, destination_id, provider_key),
+            time=ttl,
+            value=encode(fp, delivered, n),
+        )
+    except Exception as e:
+        logger.warning(f"Error writing batch progress to cache: {e}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_batch_progress.py -v`
+Expected: PASS (17 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/batch_progress.py tests/test_batch_progress.py
+git commit -m "feat: add never-raising Redis accessors for batch progress"
+```
+
+---
+
+### Task 3: Settings for the new record and the transition flag
+
+**Files:**
+- Modify: `core/settings.py:55-60`
+
+**Interfaces:**
+- Produces: `settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL` (int), `settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED` (bool)
+
+- [ ] **Step 1: Add the settings**
+
+In `core/settings.py`, immediately after the existing `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL` line, add:
+
+```python
+# Idempotency record for batch-delivered observations: ONE key per envelope
+# holding an item-sequence fingerprint plus a delivered-item bitmap. Must
+# exceed the PubSub retry window (MAX_EVENT_AGE_SECONDS, 86400 in prod) so
+# envelope redeliveries keep skipping delivered items. Replaces the per-item
+# dispatched_observation keys that filled prod Redis on 2026-08-05.
+DISPATCHED_BATCH_PROGRESS_CACHE_TTL = env.int("DISPATCHED_BATCH_PROGRESS_CACHE_TTL", 90000)
+# Transitional: when an envelope has no progress record, fall back to reading
+# the legacy per-item dispatched_observation keys. Stops the deploy from
+# re-posting everything already delivered for envelopes in flight at rollout.
+# Set false >=25h after deploy, then delete the fallback (see the design doc).
+BATCH_DEDUP_LEGACY_FALLBACK_ENABLED = env.bool("BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", True)
+```
+
+Leave `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL` in place for now; it is removed in the follow-up PR described in Task 5.
+
+- [ ] **Step 2: Verify settings import cleanly**
+
+Run: `python -c "from core import settings; print(settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL, settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED)"`
+Expected: `90000 True`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/settings.py
+git commit -m "feat: add batch progress TTL and legacy-fallback settings"
+```
+
+---
+
+### Task 4: Rewire `dispatch_observations_batch_v2` onto the progress record
+
+Replace the N-`GET` filter with one read, and the N-`SETEX` writes with one flush per chunk. Includes the legacy dual-read fallback, since read-path behaviour is a single reviewable unit.
+
+**Files:**
+- Modify: `core/event_handlers.py:17-27` (imports), `core/event_handlers.py:411-421` (delete `_cache_item_as_dispatched`), `core/event_handlers.py:424-530` (handler)
+- Test: `tests/test_process_observation_batches_v2.py`
+
+**Interfaces:**
+- Consumes: `batch_progress.fingerprint`, `.read_progress`, `.write_progress`, `.decode` (Tasks 1-2); `settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL`, `settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED` (Task 3).
+- Produces: no new public names. `_cache_item_as_dispatched` is **removed**; `_flush_progress(batch, destination_id, fp, delivered)` and `_legacy_delivered_indices(batch, destination_id)` are added as module-private helpers.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_process_observation_batches_v2.py`, add these helpers next to the existing `_dispatched_observation_setex_calls`:
+
+```python
+def _progress_setex_calls(mock_cache):
+    return [
+        call for call in mock_cache.setex.call_args_list
+        if call.kwargs.get("name", "").startswith("batch_progress.")
+    ]
+
+
+def _progress_value(items_count, delivered, gundi_ids=None):
+    """Build a record matching what _make_batch_request's items fingerprint to."""
+    from types import SimpleNamespace
+
+    from core import batch_progress
+
+    ids = gundi_ids or [f"23ca4b15-18b6-4cf4-9da6-36dd69c6f63{i}" for i in range(items_count)]
+    items = [SimpleNamespace(gundi_id=g) for g in ids]
+    return batch_progress.encode(batch_progress.fingerprint(items), delivered, items_count)
+```
+
+The gundi_ids in `_progress_value` must stay in sync with `_make_batch_request`,
+which generates `23ca4b15-18b6-4cf4-9da6-36dd69c6f63{i}` — the fingerprint is
+computed over exactly those, so a drift here silently turns every
+progress-record test into a fingerprint-mismatch test.
+
+Then add these tests:
+
+```python
+@pytest.mark.asyncio
+async def test_batch_writes_one_progress_record_instead_of_per_item_keys(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert _dispatched_observation_setex_calls(mock_cache_empty) == []
+    calls = _progress_setex_calls(mock_cache_empty)
+    assert len(calls) == 1
+    assert calls[0].kwargs["time"] == settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL
+    assert calls[0].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_reads_progress_once_not_per_item(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=25))
+
+    progress_reads = [
+        call for call in mock_cache_empty.get.call_args_list
+        if str(call.args[0]).startswith("batch_progress.")
+    ]
+    assert len(progress_reads) == 1
+    assert not any(
+        str(call.args[0]).startswith("dispatched_observation.")
+        for call in mock_cache_empty.get.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_skips_items_already_marked_in_bitmap(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # Leading None is get_integration_details' own config-cache miss.
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, _progress_value(3, {0}))
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 2
+    # The flush unions the pre-existing bit with the newly delivered ones
+    assert _progress_setex_calls(mock_cache)[-1].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_fully_delivered_posts_nothing_but_still_publishes(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, _progress_value(3, {0, 1, 2}))
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert not mock_erclient_class.return_value._post.called
+    # The original attempt may have died after recording progress and before
+    # publishing, so the delivered event must still go out for ALL items.
+    assert mock_pubsub_client.PublisherClient.return_value.publish.called
+
+
+@pytest.mark.asyncio
+async def test_batch_fingerprint_mismatch_reposts_everything(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # A record whose bits are all set, but computed over DIFFERENT item ids -
+    # positional bits are meaningless, so it must fail open.
+    stale = _progress_value(3, {0, 1, 2}, gundi_ids=["other-0", "other-1", "other-2"])
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, stale)
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 3
+
+
+@pytest.mark.asyncio
+async def test_batch_flushes_progress_per_chunk(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "ER_BULK_SIZE", 2)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    calls = _progress_setex_calls(mock_cache_empty)
+    assert len(calls) == 2  # one per chunk
+    assert calls[0].kwargs["value"][8:] == bytes([0b00000011])
+    assert calls[1].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_persists_progress_before_raising_on_transient_error(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "ER_BULK_SIZE", 2)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+    err = ERClientException("ER error ON POST: service unavailable")
+    err.status_code = 503
+    mock_erclient_class.return_value._post.side_effect = [None, err]
+
+    with pytest.raises(Exception):
+        await process_request(_make_batch_request(mocker, items_count=3))
+
+    # Chunk 1's progress must be durable before the nack, or redelivery
+    # re-posts it.
+    calls = _progress_setex_calls(mock_cache_empty)
+    assert len(calls) == 1
+    assert calls[0].kwargs["value"][8:] == bytes([0b00000011])
+
+
+@pytest.mark.asyncio
+async def test_batch_permanent_error_marks_only_individually_delivered_items(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+    bulk_err = ERClientException("ER error ON POST: bad request")
+    bulk_err.status_code = 400
+    mock_erclient_class.return_value._post.side_effect = bulk_err
+    item_err = ERClientException("ER error: bad record")
+    item_err.status_code = 400
+    mock_erclient_class.return_value.post_sensor_observation.side_effect = [None, item_err, None]
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    # Items 0 and 2 succeeded individually; item 1 failed and keeps its bit
+    # unset so redelivery retries it.
+    assert _progress_setex_calls(mock_cache_empty)[-1].kwargs["value"][8:] == bytes([0b00000101])
+
+
+@pytest.mark.asyncio
+async def test_batch_falls_back_to_legacy_per_item_keys(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+    dispatched_event,
+):
+    # No progress record; legacy key present for item 0 only. Order of gets:
+    # config cache, progress, then one per item for the legacy sweep.
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, None, dispatched_event.json(), None, None)
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", True)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 2
+    # The envelope migrates to the new format, including the legacy-derived bit
+    assert _progress_setex_calls(mock_cache)[-1].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_does_not_read_legacy_keys_when_fallback_disabled(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert not any(
+        str(call.args[0]).startswith("dispatched_observation.")
+        for call in mock_cache_empty.get.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_delivers_normally_when_cache_read_and_write_fail(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.return_value = None
+    mock_cache.setex.side_effect = RuntimeError("redis down")
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))  # must not raise
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_process_observation_batches_v2.py -v`
+Expected: the new tests FAIL (no `batch_progress.` keys are written yet, so `_progress_setex_calls` returns `[]`)
+
+- [ ] **Step 3: Update the imports**
+
+In `core/event_handlers.py`, add `batch_progress` to the `core` import on line 16 and drop the now-unused `mark_observation_dispatched` from the `core.utils` import block:
+
+```python
+from core import tracing, dispatchers, settings, throttling, batch_progress
+from core.errors import ReferenceDataError, DispatcherException
+from core.utils import (
+    ExtraKeys,
+    get_integration_details,
+    get_dispatched_observation,
+    cache_dispatched_observation,
+    is_observation_dispatched,
+    is_null,
+    publish_event,
+)
+```
+
+`is_observation_dispatched` stays — the legacy fallback uses it.
+
+- [ ] **Step 4: Replace `_cache_item_as_dispatched` with the new helpers**
+
+Delete the whole `_cache_item_as_dispatched` function (`core/event_handlers.py:411-421`) and put these in its place:
+
+```python
+def _flush_progress(batch, destination_id, fp, delivered):
+    # One write per chunk, not per item. Called after every successful chunk so
+    # progress is durable BEFORE the transient-error branch raises to nack.
+    batch_progress.write_progress(
+        batch_id=batch.batch_id,
+        destination_id=destination_id,
+        provider_key=batch.provider_key,
+        fp=fp,
+        delivered=delivered,
+        n=len(batch.items),
+        ttl=settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL,
+    )
+
+
+def _legacy_delivered_indices(batch, destination_id):
+    # Transitional: envelopes in flight when the progress record shipped carry
+    # per-item dispatched_observation keys instead. Reading them for one 25h
+    # window (> MAX_EVENT_AGE_SECONDS) keeps the deploy from re-posting
+    # everything already delivered. Deleted with the flag.
+    return {
+        index for index, item in enumerate(batch.items)
+        if is_observation_dispatched(
+            gundi_id=str(item.gundi_id), destination_id=destination_id
+        )
+    }
+```
+
+- [ ] **Step 5: Rewire the read path**
+
+In `dispatch_observations_batch_v2`, replace the `pending = [...]` list comprehension and its surrounding lines (`core/event_handlers.py`, the block starting `# Skip items already delivered`) with:
+
+```python
+        if not batch.items:
+            # Empty batches are valid to parse and are a no-op by contract
+            # (see gundi_core/events/batches.py).
+            return
+
+        fp = batch_progress.fingerprint(batch.items)
+        delivered = batch_progress.decode(
+            batch_progress.read_progress(
+                batch.batch_id, destination_id, batch.provider_key
+            ),
+            fp,
+            len(batch.items),
+        )
+        dedup_source = "batch_progress" if delivered else "none"
+        if not delivered and settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED:
+            legacy = _legacy_delivered_indices(batch, destination_id)
+            if legacy:
+                delivered = legacy
+                dedup_source = "legacy"
+        current_span.set_attribute("dedup_source", dedup_source)
+
+        # Skip items already delivered — makes envelope redelivery idempotent
+        pending = [
+            (index, item) for index, item in enumerate(batch.items)
+            if index not in delivered
+        ]
+```
+
+Move the `if not batch.items: return` guard to sit immediately after `destination_id`/`stream_type` are assigned and the span attributes are set, but **before** the `get_integration_details` call — an empty envelope should not cost a portal lookup.
+
+- [ ] **Step 6: Rewire the write path**
+
+Within the chunk loop, `chunk` is now a list of `(index, item)` pairs. Make these four edits:
+
+The bulk send:
+
+```python
+                await dispatcher.send([item.observation for _, item in chunk])
+```
+
+The per-item fallback loop header and its success branch:
+
+```python
+                    fallback_delivered_any = False
+                    for index, item in chunk:
+                        single_dispatcher = dispatchers.ERObservationDispatcher(
+                            integration=destination_integration,
+                            provider=batch.provider_key,
+                        )
+                        try:
+                            await single_dispatcher.send(item.observation)
+                        except Exception as item_exc:
+                            logger.warning(
+                                f"Observation {item.gundi_id} in batch {batch.batch_id} failed individually: {item_exc}"
+                            )
+                            await _publish_item_delivery_failed(batch, item, item_exc)
+                        else:
+                            delivered.add(index)
+                            delivered_gundi_ids.append(str(item.gundi_id))
+                            fallback_delivered_any = True
+                    _flush_progress(batch, destination_id, fp, delivered)
+                    if fallback_delivered_any:
+```
+
+The successful-chunk branch:
+
+```python
+            else:
+                for index, item in chunk:
+                    delivered.add(index)
+                    delivered_gundi_ids.append(str(item.gundi_id))
+                _flush_progress(batch, destination_id, fp, delivered)
+                throttling.record_success(destination_id=destination_id, stream_type=stream_type)
+```
+
+Leave the transient branch's `record_distress` / `_publish_batch_delivered` / `raise` sequence unchanged — it deliberately does **not** flush, because every previously completed chunk already did.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `pytest -v`
+Expected: PASS. The pre-existing `test_process_observations_batch_posts_one_bulk_request` and `test_batch_skips_already_delivered_items` assert on per-item `dispatched_observation.*` writes, which no longer happen — update those two to assert on `_progress_setex_calls` instead, matching the new tests. Do not weaken them; they should assert the same delivery outcomes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/event_handlers.py tests/test_process_observation_batches_v2.py
+git commit -m "feat: dedup batch redelivery per envelope instead of per observation"
+```
+
+---
+
+### Task 5: Document the mechanism, env vars, and rollout runbook
+
+**Files:**
+- Modify: `CLAUDE.md` (the `### Redis usage (core/utils.py)` section at ~line 79, the `### Key modules` list at ~line 91, and `## Key env vars` at ~line 109)
+- Create: `docs/rollout-envelope-dedup.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces: no code.
+
+- [ ] **Step 1: Update `CLAUDE.md`**
+
+Retitle the Redis section to `### Redis usage (core/utils.py, core/batch_progress.py)` and add:
+
+```markdown
+- **Batch idempotency** (`core/batch_progress.py`): ONE key per envelope,
+  `batch_progress.{batch_id}.{destination_id}.{sha256(provider_key)[:8]}`, whose
+  value is an 8-byte item-sequence fingerprint followed by a delivered-item
+  bitmap. TTL `DISPATCHED_BATCH_PROGRESS_CACHE_TTL` (90000s) must exceed
+  `MAX_EVENT_AGE_SECONDS`. This replaced one `dispatched_observation.*` key per
+  observation, which filled prod Redis on 2026-08-05 (33.7M keys / 10 GB).
+  `provider_key` is part of the key because cdip-routing groups items per
+  `(destination, effective_provider_key)`.
+- The fingerprint exists because cdip-routing can re-publish the same
+  `batch_id` with a different item list; a mismatch fails open and re-posts.
+- **The single-item path still writes per-observation keys** at
+  `DISPATCHED_OBSERVATIONS_CACHE_TTL` (1h) — `get_dispatched_observation` needs
+  the stored `external_id` to resolve `related_to` for attachments.
+```
+
+Add to `### Key modules`:
+
+```markdown
+- `core/batch_progress.py` — per-envelope redelivery-dedup records (pure
+  encode/decode plus never-raising Redis accessors)
+```
+
+Add to `## Key env vars`:
+
+```markdown
+- `DISPATCHED_BATCH_PROGRESS_CACHE_TTL` (default 90000) — batch dedup record
+  lifetime; must exceed `MAX_EVENT_AGE_SECONDS`
+- `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED` (default true) — transitional; read
+  legacy per-item keys when an envelope has no progress record
+```
+
+- [ ] **Step 2: Write the rollout runbook**
+
+Create `docs/rollout-envelope-dedup.md`:
+
+```markdown
+# Rollout: envelope-scoped batch dedup
+
+Ordering matters. Purging `dispatched_observation.*` before step 4 breaks the
+legacy fallback and recreates the duplicate burst it exists to prevent.
+
+1. **Scale prod Redis up.** Independent of this change and more urgent:
+   `sintegrate-4bb07e9c` (project `cdip-prod1-78ca`, region `us-central1`) is a
+   10 GB instance that hit 100%. Size for peak observation rate x 25h until this
+   ships, then it can come back down.
+2. **Deploy** with `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=true` (the default).
+   Confirm in traces that `dedup_source` is `batch_progress` for new envelopes
+   and `legacy` for in-flight ones.
+3. **Wait at least 25h** — longer than `MAX_EVENT_AGE_SECONDS` (86400), so no
+   envelope predating the deploy can still be redelivered.
+4. **Set `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=false`** and redeploy. Confirm
+   `dedup_source` is never `legacy`.
+5. **Optionally purge leftovers.** `dispatched_observation.*` keys expire on
+   their own within 25h of their last write; `scripts/redis_stale_key_cleaner.py`
+   in the `cdip` repo (branch `backup/redis-prod-cleanup-prerebase`) can UNLINK
+   them sooner.
+6. **Scale Redis back down** once db3 is at its new steady state (~0.1-0.2 GB).
+7. **Follow-up PR:** delete `_legacy_delivered_indices`,
+   `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED`, `utils.mark_observation_dispatched`,
+   and `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL`.
+
+## Verifying in prod
+
+Profile the keyspace read-only from a portal pod (Memorystore has no public
+route and `CONFIG GET` is disabled):
+
+    kubectl --context gundi-prod -n application exec -i <admin-portal-pod> \
+      -c admin-portal -- python3 - < script.py
+
+db3 is the ER dispatcher's keyspace. Expect `batch_progress.*` to dominate and
+`dispatched_observation.*` to shrink to zero over 25h.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md docs/rollout-envelope-dedup.md
+git commit -m "docs: document envelope-scoped batch dedup and its rollout"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Problem/Goals → Tasks 1-4. Non-goals respected: no task touches the single-item path, events, or attachments. Design §1 module → Task 1+2. §2 key → Task 1 (`progress_key`, with the provider_key rationale in tests and comments). §3 value → Task 1 (`encode`/`decode`). §4 read path → Task 4 Step 5, including the `dedup_source` span attribute and the preserved "everything already delivered" publish. §5 write path → Task 4 Step 6, including the no-op-when-empty rule (Task 2) and per-chunk flush. §6 rollout → Task 3 (flag), Task 4 Step 4 (`_legacy_delivered_indices`), Task 5 Step 2 (runbook with the purge-ordering warning). §7 config → Task 3. §8 impact → Task 5 docs. Accepted trade-offs: fingerprint mismatch, Redis errors, missing/truncated values, empty batch, and 4xx fallback each have a named test in Task 1 or 4. The concurrency race is documented as accepted, with the Lua OR-merge listed as a follow-up — no task, by design. Testing section → every listed case maps to a test in Task 1, 2, or 4.
+
+**Placeholder scan:** No TBD/TODO. Every code step contains runnable code, and the one fragile coupling in the test helpers (`_progress_value`'s gundi_ids must match `_make_batch_request`'s) is called out explicitly where it matters, because drift there degrades tests silently instead of failing loudly.
+
+**Type consistency:** `fingerprint`/`encode`/`decode`/`progress_key` signatures are identical across Tasks 1, 2, and 4. `write_progress` is called with keyword args matching its definition (`fp`, `delivered`, `n`, `ttl`). `chunk` becomes `list[tuple[int, item]]` in Task 4 and every consumer (`dispatcher.send`, the fallback loop, the success loop) is updated to unpack it. `delivered` is a `set[int]` throughout. `_flush_progress` and `_legacy_delivered_indices` are used only where defined.

--- a/docs/superpowers/plans/2026-08-05-envelope-scoped-batch-dedup.md
+++ b/docs/superpowers/plans/2026-08-05-envelope-scoped-batch-dedup.md
@@ -923,8 +923,16 @@ legacy fallback and recreates the duplicate burst it exists to prevent.
    10 GB instance that hit 100%. Size for peak observation rate x 25h until this
    ships, then it can come back down.
 2. **Deploy** with `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=true` (the default).
-   Confirm in traces that `dedup_source` is `batch_progress` for new envelopes
-   and `legacy` for in-flight ones.
+   Check `dedup_source` in traces, but expect `none` to dominate — a brand-new
+   envelope's *first* delivery has no progress record yet, so `none` is the
+   healthy steady-state value, not a sign of failure. `batch_progress` appears
+   only on redelivery of an envelope that already flushed progress once, and
+   `unusable_record` only on a fingerprint mismatch or truncated record (rare;
+   worth investigating if it is not). `legacy` should appear only for
+   envelopes published before the deploy. The signal that actually matters
+   here is **`legacy` decaying to zero over the 25h window** — that is what
+   confirms every pre-deploy envelope has drained, not the presence of
+   `batch_progress`.
 3. **Wait at least 25h** — longer than `MAX_EVENT_AGE_SECONDS` (86400), so no
    envelope predating the deploy can still be redelivered.
 4. **Set `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=false`** and redeploy. Confirm

--- a/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
+++ b/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
@@ -1,0 +1,321 @@
+# Batch Envelope Redelivery Dedup: O(envelopes) Instead of O(observations)
+
+Status: approved, ready for implementation planning
+Date: 2026-08-05
+
+## Problem
+
+The batch delivery path writes one Redis key per observation per destination:
+
+```
+dispatched_observation.{gundi_id}.{destination_id}   ->  "1"   TTL 90000s (25h)
+```
+
+Resident keys are therefore `observation_rate x 25h`, which has no bounded
+steady state that fits the instance. On 2026-08-05 prod Redis
+(`sintegrate-4bb07e9c`, 10 GB, project `cdip-prod1-78ca`) filled completely:
+
+- db3 held **33.7M keys / 10.00 GB of 10 GB**, 99.9% `dispatched_observation.*`,
+  averaging 223 bytes per key, TTL histogram peaking in the 24-26h bucket.
+- **96% of those keys belonged to one destination** — `89647e08-fd7a-4e97-9059-d0a75b672d56`
+  ("Wildlife Dynamics - Gundi Service Account"), whose topic went from ~400 to
+  ~800K messages/day on 2026-08-04.
+- Growth ran at ~1.7M keys/hour (~470/s) with no plateau; projected steady state
+  is ~42M keys / ~9.4 GB for db3 alone.
+- At 100% with `maxmemory-policy=volatile-lru`, Redis evicts the very
+  idempotency keys the 25h TTL exists to protect — so dedup is already
+  degraded during saturation, and the dispatcher's ER token cache (also db3,
+  also volatile) is evictable too.
+
+The 25h TTL itself is correct and must not be shortened: it has to exceed
+prod's `MAX_EVENT_AGE_SECONDS=86400`, or a PubSub redelivery arriving after
+expiry re-posts delivered items (ER 409s plus throttling distress). The defect
+is the *cardinality*, not the lifetime.
+
+Two things are explicitly **not** the cause, and were ruled out by inspection:
+the `ef7e398` TTL-env-var fix (prod sets neither `PORTAL_CONFIG_OBJECT_CACHE_TTL`
+nor `DISPATCHED_OBSERVATIONS_CACHE_TTL`, so the value was the 3600 default both
+before and after), and ER token caching (one key per destination, ~100 total).
+The `5b93c84` sentinel fix did help — 223 B observed versus ~380 B for the full
+`DispatchedObservation` JSON — but a 2-2.5x saving cannot absorb a 25x TTL.
+
+## Goals
+
+- Make redelivery dedup cost `O(envelopes)` in both memory and Redis commands.
+- Preserve the existing idempotency guarantee for redelivery of the *same*
+  envelope, which is what PubSub's at-least-once actually produces.
+- Keep the 25h lifetime and its relationship to `MAX_EVENT_AGE_SECONDS`.
+- Deploy without a duplicate burst from envelopes in flight at deploy time.
+- Never let the dedup layer raise; a broken cache must not stall the stream.
+
+## Non-goals
+
+- The single-item path. `cache_dispatched_observation` keeps writing
+  per-observation keys at the 1h TTL: `get_dispatched_observation` needs the
+  stored `external_id` to resolve `related_to` for attachment delivery. Events
+  and attachments are untouched.
+- Globally-scoped per-observation dedup. Suppressing a duplicate that arrives
+  in a *different* envelope is dropped as a requirement (see "Accepted
+  trade-offs").
+- Today's saturation. Scaling the instance is a separate, more urgent operational
+  action; this design fixes the steady state.
+- Whether the Wildlife Dynamics volume is a runaway backfill. Independent
+  investigation.
+
+## Design
+
+### 1. New module `core/batch_progress.py`
+
+`core/utils.py` is already ~450 lines with mixed responsibilities, so the new
+logic lands in its own module. The encode/decode/fingerprint functions are pure
+so the interesting logic is testable without touching Redis.
+
+```
+progress_key(batch_id, destination_id, provider_key) -> str
+fingerprint(items) -> bytes                       # pure
+encode(fingerprint, delivered, n) -> bytes        # pure
+decode(raw, expected_fingerprint, n) -> set[int]  # pure
+read_progress(batch_id, destination_id, provider_key) -> bytes | None
+write_progress(batch_id, destination_id, provider_key, fingerprint, delivered, n, ttl) -> None
+```
+
+`read_progress` / `write_progress` wrap `utils._cache_db` and swallow every
+exception (logging a warning), mirroring `is_observation_dispatched`.
+
+### 2. The key
+
+```
+batch_progress.{batch_id}.{destination_id}.{sha256(provider_key)[:8]}
+```
+
+`provider_key` **must** participate: `cdip-routing` groups transformed items per
+`(destination, effective_provider_key)` because field mappings can override the
+provider key per item and one ER bulk post allows exactly one key in its URL
+path. One `batch_id` + `destination_id` therefore legitimately yields several
+envelopes with disjoint item sets, and omitting `provider_key` would collide
+them.
+
+It is hashed rather than embedded literally because it is a free-form string
+that may contain `.` or `:`, which would break prefix-bucketed key analysis
+(`scripts/redis_ops_common.key_prefix` splits on exactly those characters) and
+make the key length unbounded.
+
+### 3. The value
+
+A single binary string written with `SET ... EX <ttl>`:
+
+```
+bytes 0..7   fingerprint = sha256("|".join(str(i.gundi_id) for i in batch.items))[:8]
+bytes 8..    bitmap; bit i set  <=>  batch.items[i] was delivered
+```
+
+Bit `i` indexes into the **received** `batch.items` list. The fingerprint binds
+the bitmap to the exact item-identity sequence it was computed against, which is
+what makes positional indexing safe (see "Accepted trade-offs").
+
+Size for a ~50-item envelope: 8 + 7 = 15 bytes of value, ~85 bytes of key name,
+~50 bytes of Redis overhead — about **150 B per envelope**, against
+50 x 223 B = ~11 KB today.
+
+### 4. Read path
+
+Replaces the N-way `is_observation_dispatched` filter in
+`dispatch_observations_batch_v2` with one `GET`:
+
+```python
+if not batch.items:
+    return  # empty batches parse as a no-op (see gundi_core/events/batches.py)
+
+fp = batch_progress.fingerprint(batch.items)
+raw = batch_progress.read_progress(batch.batch_id, destination_id, batch.provider_key)
+delivered = batch_progress.decode(raw, fp, n=len(batch.items))
+if not delivered and settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED:
+    delivered = _legacy_delivered_indices(batch, destination_id)   # see section 6
+pending = [(i, item) for i, item in enumerate(batch.items) if i not in delivered]
+```
+
+`current_span` gains a `dedup_source` attribute (`batch_progress` | `legacy` |
+`none`) so the rollout can be observed in traces.
+
+The existing "everything already delivered" branch is preserved verbatim: when
+`pending` is empty it still publishes `ObservationsBatchDelivered` for **all**
+items, because the original attempt may have died after recording progress and
+before publishing.
+
+### 5. Write path
+
+Progress flushes **once per chunk**, never per item. This is load-bearing: the
+transient-error branch raises to nack the envelope, so progress for
+already-delivered chunks must be durable *before* that raise, or redelivery
+re-posts them.
+
+```python
+for chunk in _chunked(pending, settings.ER_BULK_SIZE):
+    await dispatcher.send([item.observation for _, item in chunk])
+    delivered.update(i for i, _ in chunk)
+    batch_progress.write_progress(..., fp, delivered, len(batch.items),
+                                  ttl=settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL)
+```
+
+The per-item 4xx fallback loop sets bits only for items that succeeded
+individually, then flushes once after the loop. Items that failed individually
+keep their bit unset and are retried on redelivery — identical to today, since
+those items are not cached now either.
+
+`write_progress` is a no-op when `delivered` is empty. An all-zero record
+carries no information and would be indistinguishable from a missing one, so
+never writing it keeps `decode`'s "empty set" result unambiguous: it always
+means "nothing known to be delivered", whether the record is absent or
+unusable. The fallback loop can reach its flush having delivered nothing (every
+item failed individually), which is the case this rule covers.
+
+`_cache_item_as_dispatched` is deleted. `mark_observation_dispatched` in
+`core/utils.py` becomes unused once the legacy fallback is removed (section 6)
+and is deleted with it.
+
+### 6. Rollout: dual-read for one 25h window
+
+At deploy there are up to `MAX_EVENT_AGE_SECONDS` (24h) of in-flight envelopes
+whose items were already delivered and recorded as per-item keys. New code would
+find no `batch_progress` key and re-post all of them — a duplicate burst exactly
+when the system is shedding load.
+
+For one window, a missing progress record falls back to the legacy per-item
+check:
+
+```python
+def _legacy_delivered_indices(batch, destination_id):
+    return {
+        i for i, item in enumerate(batch.items)
+        if is_observation_dispatched(gundi_id=str(item.gundi_id),
+                                     destination_id=destination_id)
+    }
+```
+
+The batch path **only ever writes the new format**. No new per-item key is
+created, so the existing 33.7M keys drain by TTL and the population strictly
+shrinks.
+
+Cost during the window: envelopes without a progress record still pay N GETs,
+including on the *first* delivery of a brand-new envelope. That is exactly
+today's read cost, so the window is neutral-to-better, and the memory win starts
+immediately.
+
+Sequence, and the ordering matters:
+
+1. Scale the instance up (independent of this change; do it now).
+2. Deploy with `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=true`.
+3. Wait at least 25h.
+4. Set `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED=false`.
+5. Optionally `UNLINK` leftover `dispatched_observation.*` keys.
+6. Scale the instance back down.
+7. Follow-up PR: delete the fallback, `mark_observation_dispatched`, and
+   `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL`.
+
+**Do not purge `dispatched_observation.*` before step 4** — the fallback reads
+those keys, and purging early reintroduces the duplicate burst it exists to
+prevent.
+
+### 7. Configuration
+
+| Setting | Default | Notes |
+|---|---|---|
+| `DISPATCHED_BATCH_PROGRESS_CACHE_TTL` | `90000` | Must exceed `MAX_EVENT_AGE_SECONDS` (86400). Same rationale as the TTL it replaces. |
+| `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED` | `true` | Flip to `false` after >=25h in prod, then delete. |
+| `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL` | `90000` | Becomes unused the moment this ships — the fallback only *reads* legacy keys and writes none. Deleted in the follow-up PR alongside the fallback. |
+
+### 8. Expected impact
+
+| | Today | After |
+|---|---|---|
+| Keys resident | 33.7M (heading for ~42M) | ~830K |
+| db3 memory | ~9.4 GB projected steady state | ~0.1-0.2 GB |
+| Redis reads per envelope | N `GET` | 1 `GET` |
+| Redis writes per envelope | N `SETEX` | ~1 `SET` per chunk |
+
+At the ~50 items per envelope implied by current traffic (~40M keys/day against
+~800K envelopes/day), that is a ~50x reduction per envelope in both keys and
+commands, a ~40x drop in resident keys against today's saturated figure, and a
+~50-90x reduction in memory.
+
+## Accepted trade-offs
+
+Every failure mode fails open — `delivered` becomes empty, items are re-posted,
+and nothing raises. Duplicates are the failure currency; lost observations are
+never acceptable.
+
+| Condition | Behaviour |
+|---|---|
+| Fingerprint mismatch | `delivered = {}`, re-post all N. Duplicates, no loss. |
+| Same envelope delivered concurrently to two workers | Both read-modify-write; last write wins, some bits lost, those items re-posted later. Duplicates, no loss. |
+| Redis unavailable or any exception | `delivered = {}`. Matches `is_observation_dispatched`, which returns `False` on error. |
+| Value missing, truncated, or shorter than `ceil(n/8)` | Absent bits count as not delivered. |
+| `batch.items == []` | Early return, nothing written. |
+| Item fails individually in the 4xx fallback | Bit unset, retried on redelivery. Unchanged from today. |
+
+Two of these deserve explicit justification.
+
+**Why a fingerprint is required.** `transform_and_route_observations_batch` can
+publish some groups and *then* raise, retrying the whole
+`ObservationsBatchReceived`; and per-item transform failures `continue` to shrink
+the batch rather than abort it. A transform failure that is transient can
+therefore succeed on the retry, so the same `batch_id` may be re-published with
+a *different item list or order*. Without the fingerprint, bit `i` from the first
+attempt would be read as authoritative for a different observation in the
+second — silently skipping an undelivered item. That is data loss, the one
+outcome ruled out. The fingerprint converts it into a detectable mismatch that
+fails open.
+
+**Why the concurrency race is tolerated.** Today each item's `SETEX` is
+independent, so nothing can be clobbered; a shared read-modify-write value
+introduces a lost-update window that did not previously exist. A Lua OR-merge
+would close it, but it only converts rare duplicates into rarer duplicates, and
+duplicates on mismatch are already accepted. Noted as a follow-up should the
+duplicate rate prove material in practice.
+
+**Why per-envelope scoping is acceptable.** A `gundi_id` is assigned when Gundi
+ingests an observation, so a re-pull produces new ids rather than resurfacing
+old ones; the realistic duplicate scenario is redelivery or re-publication of
+the same envelope, which keys on `batch_id` and is still covered. If a single
+`gundi_id` ever did reach one destination through two distinct envelopes, it
+would now be posted twice.
+
+## Testing
+
+The suite mocks Redis with `MagicMock` (`tests/conftest.py`'s `mock_cache_*`
+fixtures); there is no `fakeredis` in this repo. Keeping encode/decode/fingerprint
+pure means the bit-level logic needs no mocking at all.
+
+**Pure functions**
+
+- `fingerprint` is stable across identical id sequences, and differs on reorder,
+  on an added item, and on a removed item.
+- `encode` -> `decode` round-trips for n = 0, 1, 7, 8, 9, 200 (byte-boundary cases).
+- `decode` returns `{}` for `None`, for a value shorter than 8 bytes, and for a
+  mismatched fingerprint.
+- `decode` treats a bitmap shorter than `ceil(n/8)` as having only the bits present.
+
+**Handler behaviour**
+
+- First delivery: one read, all bits set, TTL applied.
+- Redelivery with a full bitmap: no ER post, but `ObservationsBatchDelivered` is
+  still published for all items.
+- Redelivery with a partial bitmap: only unset items posted.
+- Transient failure mid-envelope: progress for completed chunks is persisted
+  *before* the exception propagates.
+- 4xx fallback: bits set only for individually-successful items.
+- Fingerprint mismatch: every item re-posted.
+- Legacy fallback enabled, no progress record, legacy per-item keys present:
+  `pending` excludes those items; `dedup_source` is `legacy`.
+- Legacy fallback disabled: no per-item reads occur.
+- Redis raising on read, and on write: never propagates, delivery proceeds.
+
+## Follow-ups
+
+- Optional Lua OR-merge for the concurrent-redelivery race.
+- Remove the legacy fallback, `mark_observation_dispatched`, and
+  `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL` after the window closes.
+- Land `redis_memory_profiler.py` / `redis_stale_key_cleaner.py` on main in the
+  `cdip` repo (currently only on `backup/redis-prod-cleanup-prerebase`).
+- Determine whether the Wildlife Dynamics volume is intentional or a runaway
+  backfill.

--- a/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
+++ b/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
@@ -123,7 +123,17 @@ item lists (e.g. `["a|b", "c"]` and `["a", "b|c"]`) hash identically, and a
 collision here means `decode()` reports a match against the wrong item list:
 a bit gets read as "delivered" for an observation that was never sent. That is
 the one outcome this design forbids. Fixed-width length prefixing is a uniquely
-decodable code, so two different ordered `gundi_id` sequences cannot collide.
+decodable code, so two different ordered `gundi_id` sequences never produce the
+same bytes to hash.
+
+An injective encoding is not a collision-free digest, though: the fingerprint
+truncates SHA-256 to 8 bytes, so distinct inputs can still collide at ~2^-64.
+Why 8 bytes is enough is a matter of **scope**, not of digest width — a
+fingerprint is only ever compared against records stored under the same
+`(batch_id, destination_id, provider_key)` key, and only a handful of item lists
+ever exist for one key inside its 25h lifetime. The exposure is therefore ~2^-64
+per comparison, not a birthday problem across ~800K envelopes/day. Widen
+`FINGERPRINT_BYTES` if that scoping assumption ever stops holding.
 
 Bit `i` indexes into the **received** `batch.items` list. The fingerprint binds
 the bitmap to the exact item-identity sequence it was computed against, which is

--- a/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
+++ b/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
@@ -105,9 +105,19 @@ make the key length unbounded.
 A single binary string written with `SET ... EX <ttl>`:
 
 ```
-bytes 0..7   fingerprint = sha256("|".join(str(i.gundi_id) for i in batch.items))[:8]
+bytes 0..7   fingerprint = sha256(len(items) || len(id_0) || id_0 || len(id_1) || id_1 || ...)[:8]
 bytes 8..    bitmap; bit i set  <=>  batch.items[i] was delivered
 ```
+
+The fingerprint is length-prefixed (each `gundi_id`'s byte length as a 4-byte
+big-endian integer, prefixed by the item count), not delimiter-joined.
+`gundi_id` is `Union[UUID, str]` in `gundi_core`, so a non-UUID string is
+schema-legal and may itself contain `|` — a delimiter join lets two different
+item lists (e.g. `["a|b", "c"]` and `["a", "b|c"]`) hash identically, and a
+collision here means `decode()` reports a match against the wrong item list:
+a bit gets read as "delivered" for an observation that was never sent. That is
+the one outcome this design forbids. The length-prefixed encoding is
+injective, so two different ordered `gundi_id` sequences cannot collide.
 
 Bit `i` indexes into the **received** `batch.items` list. The fingerprint binds
 the bitmap to the exact item-identity sequence it was computed against, which is
@@ -134,8 +144,15 @@ if not delivered and settings.BATCH_DEDUP_LEGACY_FALLBACK_ENABLED:
 pending = [(i, item) for i, item in enumerate(batch.items) if i not in delivered]
 ```
 
-`current_span` gains a `dedup_source` attribute (`batch_progress` | `legacy` |
-`none`) so the rollout can be observed in traces.
+`current_span` gains a `dedup_source` attribute — `batch_progress` (record
+present and usable), `unusable_record` (a record was present but `decode()`
+couldn't use it: fingerprint mismatch or truncation — the one condition that
+causes a full-envelope duplicate re-post), `legacy` (no usable record, legacy
+per-item keys found one), or `none` (no record at all — the common case for a
+brand-new envelope's first delivery) — so the rollout can be observed in
+traces. `raw` is kept around specifically so `unusable_record` can be told
+apart from `none`; without it, decode's empty set alone can't distinguish
+"nothing was ever recorded" from "something was recorded but is unusable."
 
 The existing "everything already delivered" branch is preserved verbatim: when
 `pending` is empty it still publishes `ObservationsBatchDelivered` for **all**
@@ -159,8 +176,12 @@ for chunk in _chunked(pending, settings.ER_BULK_SIZE):
 
 The per-item 4xx fallback loop sets bits only for items that succeeded
 individually, then flushes once after the loop. Items that failed individually
-keep their bit unset and are retried on redelivery — identical to today, since
-those items are not cached now either.
+keep their bit unset — identical to today, since those items are not cached
+now either. This is *not* "retried on redelivery": the 4xx fallback path acks
+the envelope and publishes `ObservationDeliveryFailed` for each item that
+failed individually, so there is no redelivery for the unset bit to be
+retried on. The bit is simply accurate bookkeeping of what was never
+delivered.
 
 `write_progress` is a no-op when `delivered` is empty. An all-zero record
 carries no information and would be indistinguishable from a missing one, so
@@ -251,7 +272,7 @@ never acceptable.
 | Redis unavailable or any exception | `delivered = {}`. Matches `is_observation_dispatched`, which returns `False` on error. |
 | Value missing, truncated, or shorter than `ceil(n/8)` | Absent bits count as not delivered. |
 | `batch.items == []` | Early return, nothing written. |
-| Item fails individually in the 4xx fallback | Bit unset, retried on redelivery. Unchanged from today. |
+| Item fails individually in the 4xx fallback | Bit unset. The envelope is acked and `ObservationDeliveryFailed` is published for that item — not retried on redelivery. Unchanged from today. |
 
 Two of these deserve explicit justification.
 

--- a/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
+++ b/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
@@ -352,6 +352,17 @@ pure means the bit-level logic needs no mocking at all.
 - Optional Lua OR-merge for the concurrent-redelivery race.
 - Remove the legacy fallback, `mark_observation_dispatched`, and
   `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL` after the window closes.
+- Consider deferring `get_integration_details()` until after the `pending`
+  calculation, so a fully-delivered redelivery needs no portal lookup and cannot
+  raise `ReferenceDataError` for work it isn't going to do. Raised by Copilot on
+  PR #46 and deliberately deferred: the ordering is pre-existing, and it is a
+  semantic change rather than a pure optimization — today such an envelope
+  nacks and reaches the DLQ at age-out, whereas reordering makes it ack
+  silently. That is arguably more correct, but it is a decision about DLQ
+  visibility and belongs in its own change with its own test, not inside a
+  Redis-cardinality fix. The payoff is also small: the config is cached at
+  `PORTAL_CONFIG_OBJECT_CACHE_TTL` (60s), and fully-delivered redeliveries only
+  happen when an attempt died between flushing progress and publishing.
 - Land `redis_memory_profiler.py` / `redis_stale_key_cleaner.py` on main in the
   `cdip` repo (currently only on `backup/redis-prod-cleanup-prerebase`).
 - ~~Determine whether the Wildlife Dynamics volume is intentional or a runaway

--- a/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
+++ b/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
@@ -59,8 +59,9 @@ The `5b93c84` sentinel fix did help — 223 B observed versus ~380 B for the ful
   trade-offs").
 - Today's saturation. Scaling the instance is a separate, more urgent operational
   action; this design fixes the steady state.
-- Whether the Wildlife Dynamics volume is a runaway backfill. Independent
-  investigation.
+- The Wildlife Dynamics volume itself. Resolved 2026-08-05: it is intentional,
+  and it is a large backfill rather than sustained traffic — so ~470 keys/s is a
+  recurring-but-transient peak, not a new baseline. Nothing to chase.
 
 ## Design
 
@@ -338,5 +339,10 @@ pure means the bit-level logic needs no mocking at all.
   `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL` after the window closes.
 - Land `redis_memory_profiler.py` / `redis_stale_key_cleaner.py` on main in the
   `cdip` repo (currently only on `backup/redis-prod-cleanup-prerebase`).
-- Determine whether the Wildlife Dynamics volume is intentional or a runaway
-  backfill.
+- ~~Determine whether the Wildlife Dynamics volume is intentional or a runaway
+  backfill.~~ Resolved 2026-08-05: intentional, and a large backfill rather than
+  sustained volume. The sizing rule that follows is to size for peak *backfill*
+  rate x TTL, not for average traffic — which is exactly what this design makes
+  cheap: the same backfill costs ~0.12 GB here versus ~9.4 GB projected under the
+  per-observation scheme, so a backfill of this size stops being a capacity event
+  and the instance needs no permanent oversizing.

--- a/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
+++ b/docs/superpowers/specs/2026-08-05-batch-envelope-dedup-design.md
@@ -110,15 +110,20 @@ bytes 0..7   fingerprint = sha256(len(items) || len(id_0) || id_0 || len(id_1) |
 bytes 8..    bitmap; bit i set  <=>  batch.items[i] was delivered
 ```
 
-The fingerprint is length-prefixed (each `gundi_id`'s byte length as a 4-byte
-big-endian integer, prefixed by the item count), not delimiter-joined.
+The fingerprint is length-prefixed, not delimiter-joined: the item count as a
+4-byte big-endian integer, then each `gundi_id`'s byte length as a 4-byte
+big-endian integer followed by its bytes. Every length field is fixed-width,
+including the count — a decimal count would itself be variable-length and would
+leave injectivity resting on a side argument about the maximum size of a single
+`gundi_id`.
+
 `gundi_id` is `Union[UUID, str]` in `gundi_core`, so a non-UUID string is
 schema-legal and may itself contain `|` — a delimiter join lets two different
 item lists (e.g. `["a|b", "c"]` and `["a", "b|c"]`) hash identically, and a
 collision here means `decode()` reports a match against the wrong item list:
 a bit gets read as "delivered" for an observation that was never sent. That is
-the one outcome this design forbids. The length-prefixed encoding is
-injective, so two different ordered `gundi_id` sequences cannot collide.
+the one outcome this design forbids. Fixed-width length prefixing is a uniquely
+decodable code, so two different ordered `gundi_id` sequences cannot collide.
 
 Bit `i` indexes into the **received** `batch.items` list. The fingerprint binds
 the bitmap to the exact item-identity sequence it was computed against, which is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import asyncio
 from erclient import er_errors
 from gundi_core.events import EventTransformedER, ObservationTransformedER, AttachmentTransformedER, \
-    EventUpdateTransformedER
+    EventUpdateTransformedER, ObservationsBatchTransformedER
 from gundi_core.schemas import OutboundConfiguration
 from gundi_core.schemas.v2 import EREvent
 from redis import exceptions as redis_exceptions

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -1,3 +1,4 @@
+import hashlib
 from types import SimpleNamespace
 
 from core import batch_progress
@@ -50,6 +51,20 @@ def test_fingerprint_does_not_collide_across_item_boundaries():
     # Decoding A's record against B's fingerprint must fail open (empty set),
     # never silently report a match against the wrong item list.
     assert batch_progress.decode(raw, fp_b, 2) == set()
+
+
+def test_fingerprint_count_prefix_is_fixed_width():
+    # The leading item count is a 4-byte big-endian integer, not decimal text.
+    # A decimal count is variable-length, which would leave injectivity resting
+    # on an argument about the largest possible single gundi_id rather than on
+    # the encoding itself. Pinning the exact digest keeps that from silently
+    # regressing to str(len(items)).
+    expected = hashlib.sha256()
+    expected.update((1).to_bytes(4, "big"))
+    raw_id = b"id-0"
+    expected.update(len(raw_id).to_bytes(4, "big"))
+    expected.update(raw_id)
+    assert batch_progress.fingerprint(_items("id-0")) == expected.digest()[:8]
 
 
 def test_encode_sets_expected_bits():

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+from core import batch_progress
+
+
+def _items(*gundi_ids):
+    return [SimpleNamespace(gundi_id=g) for g in gundi_ids]
+
+
+def test_progress_key_hashes_provider_key_and_is_delimiter_safe():
+    key = batch_progress.progress_key(
+        "8a5535df-1b9b-412b-9fd5-e29b09582222",
+        "338225f3-91f9-4fe1-b013-353a229ce504",
+        "gundi.movebank:abc123",  # contains BOTH separators
+    )
+    assert key.startswith("batch_progress.8a5535df-1b9b-412b-9fd5-e29b09582222.")
+    # 4 segments exactly: prefix, batch_id, destination_id, provider digest
+    assert len(key.split(".")) == 4
+    assert "movebank" not in key  # provider_key never appears literally
+
+
+def test_progress_key_differs_per_provider_key():
+    args = ("batch-1", "dest-1")
+    assert batch_progress.progress_key(*args, "key-a") != batch_progress.progress_key(*args, "key-b")
+
+
+def test_fingerprint_is_stable_and_order_sensitive():
+    a = batch_progress.fingerprint(_items("id-0", "id-1", "id-2"))
+    assert a == batch_progress.fingerprint(_items("id-0", "id-1", "id-2"))
+    assert len(a) == 8
+    assert a != batch_progress.fingerprint(_items("id-2", "id-1", "id-0"))  # reorder
+    assert a != batch_progress.fingerprint(_items("id-0", "id-1"))          # removed
+    assert a != batch_progress.fingerprint(_items("id-0", "id-1", "id-2", "id-3"))  # added
+
+
+def test_encode_sets_expected_bits():
+    fp = b"\x00" * 8
+    assert batch_progress.encode(fp, {0, 1, 2}, 3)[8:] == bytes([0b00000111])
+    assert batch_progress.encode(fp, {0, 2}, 3)[8:] == bytes([0b00000101])
+    assert batch_progress.encode(fp, {8}, 9)[8:] == bytes([0b00000000, 0b00000001])
+
+
+def test_encode_ignores_out_of_range_indices():
+    fp = b"\x00" * 8
+    assert batch_progress.encode(fp, {-1, 5, 99}, 3)[8:] == bytes([0b00000000])
+
+
+def test_encode_decode_round_trips_across_byte_boundaries():
+    for n in (0, 1, 7, 8, 9, 200):
+        items = _items(*[f"id-{i}" for i in range(n)])
+        fp = batch_progress.fingerprint(items)
+        delivered = set(range(0, n, 3))
+        raw = batch_progress.encode(fp, delivered, n)
+        assert batch_progress.decode(raw, fp, n) == delivered
+
+
+def test_decode_returns_empty_when_record_missing_or_truncated():
+    fp = b"\x01" * 8
+    assert batch_progress.decode(None, fp, 3) == set()
+    assert batch_progress.decode(b"", fp, 3) == set()
+    assert batch_progress.decode(b"\x01" * 7, fp, 3) == set()  # shorter than fingerprint
+
+
+def test_decode_returns_empty_on_fingerprint_mismatch():
+    # The envelope was re-published with a different item list, so positional
+    # bits no longer refer to the same observations. Must fail open.
+    items = _items("id-0", "id-1", "id-2")
+    raw = batch_progress.encode(batch_progress.fingerprint(items), {0, 1, 2}, 3)
+    other = batch_progress.fingerprint(_items("id-9", "id-8", "id-7"))
+    assert batch_progress.decode(raw, other, 3) == set()
+
+
+def test_decode_treats_short_bitmap_as_absent_bits():
+    fp = b"\x02" * 8
+    raw = fp + bytes([0b00000101])  # only 1 byte of bitmap, but n spans 2
+    assert batch_progress.decode(raw, fp, 12) == {0, 2}
+
+
+def test_decode_ignores_extra_bitmap_bytes_beyond_n():
+    fp = b"\x03" * 8
+    raw = fp + bytes([0b11111111, 0b11111111])
+    assert batch_progress.decode(raw, fp, 3) == {0, 1, 2}
+
+
+def test_decode_returns_empty_for_non_bytes_value():
+    # A cache returning a str (or anything unexpected) must fail open, not raise.
+    fp = b"\x04" * 8
+    assert batch_progress.decode("not-bytes", fp, 3) == set()

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -33,6 +33,25 @@ def test_fingerprint_is_stable_and_order_sensitive():
     assert a != batch_progress.fingerprint(_items("id-0", "id-1", "id-2", "id-3"))  # added
 
 
+def test_fingerprint_does_not_collide_across_item_boundaries():
+    # gundi_id is Union[UUID, str] in gundi_core, so a non-UUID string
+    # containing "|" is schema-legal. A delimiter join would make these two
+    # DIFFERENT item lists hash identically ("a|b" + "c" == "a" + "b|c" once
+    # joined with "|"), which would let decode() report item 0 of B ("a") as
+    # delivered because it matches A's fingerprint - a false match, which
+    # skips a never-delivered observation instead of failing open.
+    a = _items("a|b", "c")
+    b = _items("a", "b|c")
+    fp_a = batch_progress.fingerprint(a)
+    fp_b = batch_progress.fingerprint(b)
+    assert fp_a != fp_b
+
+    raw = batch_progress.encode(fp_a, {0}, 2)
+    # Decoding A's record against B's fingerprint must fail open (empty set),
+    # never silently report a match against the wrong item list.
+    assert batch_progress.decode(raw, fp_b, 2) == set()
+
+
 def test_encode_sets_expected_bits():
     fp = b"\x00" * 8
     assert batch_progress.encode(fp, {0, 1, 2}, 3)[8:] == bytes([0b00000111])
@@ -86,6 +105,16 @@ def test_decode_returns_empty_for_non_bytes_value():
     # A cache returning a str (or anything unexpected) must fail open, not raise.
     fp = b"\x04" * 8
     assert batch_progress.decode("not-bytes", fp, 3) == set()
+
+
+def test_decode_returns_empty_when_expected_fingerprint_has_wrong_length():
+    # decode() must not trust a caller-supplied fingerprint of the wrong
+    # length - it can never legitimately match a validly-encoded record, so
+    # comparing against it anyway would just be inviting a spurious match.
+    items = _items("id-0", "id-1", "id-2")
+    raw = batch_progress.encode(batch_progress.fingerprint(items), {0, 1, 2}, 3)
+    assert batch_progress.decode(raw, b"\x00" * 7, 3) == set()  # too short
+    assert batch_progress.decode(raw, b"\x00" * 9, 3) == set()  # too long
 
 
 def test_read_progress_returns_cached_value(mocker):

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -86,3 +86,53 @@ def test_decode_returns_empty_for_non_bytes_value():
     # A cache returning a str (or anything unexpected) must fail open, not raise.
     fp = b"\x04" * 8
     assert batch_progress.decode("not-bytes", fp, 3) == set()
+
+
+def test_read_progress_returns_cached_value(mocker):
+    db = mocker.MagicMock()
+    db.get.return_value = b"payload"
+    mocker.patch("core.utils._cache_db", db)
+
+    assert batch_progress.read_progress("b1", "d1", "pk") == b"payload"
+    db.get.assert_called_once_with(batch_progress.progress_key("b1", "d1", "pk"))
+
+
+def test_read_progress_returns_none_on_redis_error(mocker):
+    db = mocker.MagicMock()
+    db.get.side_effect = RuntimeError("redis down")
+    mocker.patch("core.utils._cache_db", db)
+
+    assert batch_progress.read_progress("b1", "d1", "pk") is None
+
+
+def test_write_progress_stores_encoded_record_with_ttl(mocker):
+    db = mocker.MagicMock()
+    mocker.patch("core.utils._cache_db", db)
+    fp = batch_progress.fingerprint(_items("id-0", "id-1", "id-2"))
+
+    batch_progress.write_progress("b1", "d1", "pk", fp, {0, 2}, 3, ttl=90000)
+
+    db.setex.assert_called_once_with(
+        name=batch_progress.progress_key("b1", "d1", "pk"),
+        time=90000,
+        value=fp + bytes([0b00000101]),
+    )
+
+
+def test_write_progress_is_a_noop_when_nothing_delivered(mocker):
+    # An all-zero record is indistinguishable from a missing one, so never
+    # write it - that keeps decode's empty-set result unambiguous.
+    db = mocker.MagicMock()
+    mocker.patch("core.utils._cache_db", db)
+
+    batch_progress.write_progress("b1", "d1", "pk", b"\x00" * 8, set(), 3, ttl=90000)
+
+    assert not db.setex.called
+
+
+def test_write_progress_swallows_redis_error(mocker):
+    db = mocker.MagicMock()
+    db.setex.side_effect = RuntimeError("redis down")
+    mocker.patch("core.utils._cache_db", db)
+
+    batch_progress.write_progress("b1", "d1", "pk", b"\x00" * 8, {0}, 3, ttl=90000)  # must not raise

--- a/tests/test_process_observation_batches_v2.py
+++ b/tests/test_process_observation_batches_v2.py
@@ -634,6 +634,16 @@ async def test_batch_skips_items_already_marked_in_bitmap(
     assert len(posted) == 2
     # The flush unions the pre-existing bit with the newly delivered ones
     assert _progress_setex_calls(mock_cache)[-1].kwargs["value"][8:] == bytes([0b00000111])
+    # The delivered event must cover ALL 3 items, not just the 2 this attempt
+    # sent. Item 0 was delivered by a previous attempt that flushed progress and
+    # then died before publishing; if it is left out here its trace is never
+    # stamped and downstream delivery status stays permanently incomplete.
+    (binary_payload,), _ = mock_pubsub_client.PubsubMessage.call_args
+    published_payload = json.loads(binary_payload)
+    assert published_payload["event_type"] == "ObservationsBatchDelivered"
+    assert sorted(published_payload["payload"]["gundi_ids"]) == sorted(
+        f"23ca4b15-18b6-4cf4-9da6-36dd69c6f63{i}" for i in range(3)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_process_observation_batches_v2.py
+++ b/tests/test_process_observation_batches_v2.py
@@ -534,6 +534,35 @@ async def test_too_old_batch_publishes_dead_lettered_notice(
 
 
 @pytest.mark.asyncio
+async def test_batch_with_no_items_is_a_no_op(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # Ack/nack-semantics regression test: an empty items list addressed to an
+    # UNKNOWN destination previously raised ReferenceDataError (-> nack ->
+    # eventual DLQ at age-out), because get_integration_details ran before any
+    # items check. The new `if not batch.items: return` guard runs first, so
+    # an empty batch is now a pure no-op regardless of whether the destination
+    # exists - it must return cleanly, post nothing, publish nothing, and
+    # never pay for a portal lookup it has no use for.
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    get_integration_details_mock = mocker.patch("core.event_handlers.get_integration_details")
+
+    await process_request(_make_batch_request(mocker, items_count=0))  # must not raise
+
+    assert not mock_erclient_class.return_value._post.called
+    assert not mock_erclient_class.return_value.post_sensor_observation.called
+    assert not mock_pubsub_client.PublisherClient.return_value.publish.called
+    assert not get_integration_details_mock.called
+
+
+@pytest.mark.asyncio
 async def test_batch_writes_one_progress_record_instead_of_per_item_keys(
     mocker,
     mock_cache_empty,
@@ -627,7 +656,19 @@ async def test_batch_fully_delivered_posts_nothing_but_still_publishes(
     assert not mock_erclient_class.return_value._post.called
     # The original attempt may have died after recording progress and before
     # publishing, so the delivered event must still go out for ALL items.
-    assert mock_pubsub_client.PublisherClient.return_value.publish.called
+    publish_mock = mock_pubsub_client.PublisherClient.return_value.publish
+    assert publish_mock.called
+    # This is the only progress-path test that inspects the delivered
+    # payload itself (the legacy-path equivalent at
+    # test_batch_all_cached_redelivery_still_publishes_delivered_event is
+    # deleted along with the legacy flag) - it must carry all 3 gundi_ids,
+    # not just a truthy publish call.
+    (binary_payload,), _ = mock_pubsub_client.PubsubMessage.call_args
+    published_payload = json.loads(binary_payload)
+    assert published_payload["event_type"] == "ObservationsBatchDelivered"
+    assert sorted(published_payload["payload"]["gundi_ids"]) == sorted(
+        f"23ca4b15-18b6-4cf4-9da6-36dd69c6f63{i}" for i in range(3)
+    )
 
 
 @pytest.mark.asyncio
@@ -639,6 +680,41 @@ async def test_batch_fingerprint_mismatch_reposts_everything(
 ):
     # A record whose bits are all set, but computed over DIFFERENT item ids -
     # positional bits are meaningless, so it must fail open.
+    stale = _progress_value(3, {0, 1, 2}, gundi_ids=["other-0", "other-1", "other-2"])
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, stale)
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 3
+
+
+@pytest.mark.asyncio
+async def test_batch_unusable_record_dedup_source_reposts_everything(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # dedup_source classification (core/event_handlers.py): a fingerprint
+    # mismatch means a record WAS present (raw is truthy) but decode()
+    # couldn't use it, which must be reported as "unusable_record" rather
+    # than "none" (no record at all) - that split is the only telemetry that
+    # can distinguish the one condition causing a full-envelope duplicate
+    # re-post from an ordinary first delivery.
+    #
+    # This suite has no infrastructure for asserting on OTel span attributes
+    # (the tracer is the real SDK, configured once at module import with no
+    # in-memory exporter wired in for tests - see core/tracing/config.py), so
+    # this test asserts the observable consequence of the "unusable_record"
+    # branch instead: every item gets re-posted, exactly as a missing record
+    # would, because both classifications resolve to `delivered = set()`.
     stale = _progress_value(3, {0, 1, 2}, gundi_ids=["other-0", "other-1", "other-2"])
     mock_cache = mocker.MagicMock()
     mock_cache.get.side_effect = (None, stale)
@@ -739,7 +815,11 @@ async def test_batch_permanent_error_marks_only_individually_delivered_items(
     await process_request(_make_batch_request(mocker, items_count=3))
 
     # Items 0 and 2 succeeded individually; item 1 failed and keeps its bit
-    # unset so redelivery retries it.
+    # unset. It is NOT retried on redelivery: the 4xx fallback path acks the
+    # envelope and publishes ObservationDeliveryFailed for item 1 instead of
+    # raising, so there is no redelivery to retry it on. The bit stays unset
+    # simply because it was never delivered - correct bookkeeping, not a
+    # signal that a retry is coming.
     assert _progress_setex_calls(mock_cache_empty)[-1].kwargs["value"][8:] == bytes([0b00000101])
 
 

--- a/tests/test_process_observation_batches_v2.py
+++ b/tests/test_process_observation_batches_v2.py
@@ -22,6 +22,24 @@ def _dispatched_observation_setex_calls(mock_cache):
     ]
 
 
+def _progress_setex_calls(mock_cache):
+    return [
+        call for call in mock_cache.setex.call_args_list
+        if call.kwargs.get("name", "").startswith("batch_progress.")
+    ]
+
+
+def _progress_value(items_count, delivered, gundi_ids=None):
+    """Build a record matching what _make_batch_request's items fingerprint to."""
+    from types import SimpleNamespace
+
+    from core import batch_progress
+
+    ids = gundi_ids or [f"23ca4b15-18b6-4cf4-9da6-36dd69c6f63{i}" for i in range(items_count)]
+    items = [SimpleNamespace(gundi_id=g) for g in ids]
+    return batch_progress.encode(batch_progress.fingerprint(items), delivered, items_count)
+
+
 def _make_batch_request(mocker, items_count=3, provider_key="gundi_movebank_abc123"):
     destination_id = "338225f3-91f9-4fe1-b013-353a229ce504"
     data_provider_id = "ddd0946d-15b0-4308-b93d-e0470b6d33b6"
@@ -103,8 +121,11 @@ async def test_process_observations_batch_posts_one_bulk_request(
     assert isinstance(posted, list)
     assert len(posted) == 3
     assert not mock_erclient_class.return_value.post_sensor_observation.called
-    # Every item cached as dispatched
-    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 3
+    # Delivery recorded in ONE per-envelope progress record, not per-item keys
+    assert _dispatched_observation_setex_calls(mock_cache_empty) == []
+    progress_calls = _progress_setex_calls(mock_cache_empty)
+    assert len(progress_calls) == 1
+    assert progress_calls[0].kwargs["value"][8:] == bytes([0b00000111])
     # One ObservationsBatchDelivered event published
     publish_mock = mock_pubsub_client.PublisherClient.return_value.publish
     assert publish_mock.called
@@ -138,11 +159,11 @@ async def test_batch_skips_already_delivered_items(
     mock_pubsub_client,
     dispatched_event,
 ):
-    # First item is a cache hit (already delivered); the other two must post.
-    # The leading None accounts for get_integration_details' own cache-miss
-    # read on the shared _cache_db mock, which runs before any per-item check.
+    # First item is a cache hit via the legacy per-item key (already
+    # delivered); the other two must post. Order of gets: config cache,
+    # progress record (miss), then one per item for the legacy sweep.
     mock_cache = mocker.MagicMock()
-    mock_cache.get.side_effect = (None, dispatched_event.json(), None, None)
+    mock_cache.get.side_effect = (None, None, dispatched_event.json(), None, None)
     mocker.patch("core.utils._cache_db", mock_cache)
     mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
     mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
@@ -153,6 +174,9 @@ async def test_batch_skips_already_delivered_items(
     post_mock = mock_erclient_class.return_value._post
     posted = post_mock.call_args.kwargs["payload"]
     assert len(posted) == 2
+    # The envelope migrates to the new progress-record format, including the
+    # legacy-derived bit for item 0.
+    assert _progress_setex_calls(mock_cache)[-1].kwargs["value"][8:] == bytes([0b00000111])
 
 
 @pytest.mark.asyncio
@@ -213,7 +237,12 @@ async def test_batch_400_falls_back_to_per_item_and_acks(
 
     assert bulk_post_mock.call_count == 1
     assert item_post_mock.call_count == 3
-    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 2  # only the two successes cached
+    assert _dispatched_observation_setex_calls(mock_cache_empty) == []
+    # Items 0 and 2 succeeded individually; item 1 failed and keeps its bit
+    # unset in the progress record.
+    progress_calls = _progress_setex_calls(mock_cache_empty)
+    assert len(progress_calls) == 1
+    assert progress_calls[-1].kwargs["value"][8:] == bytes([0b00000101])
 
 
 class _CloseOnceERClient:
@@ -288,8 +317,12 @@ async def test_batch_uses_a_fresh_client_per_chunk(
     all_posted = [item for client in created_clients for item in client.posted_payloads]
     assert len(all_posted) == 2  # one post per chunk
     assert sum(len(payload) for payload in all_posted) == 3  # 2 + 1 items total
-    # Every item cached as dispatched proves both chunks succeeded
-    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 3
+    # One progress flush per chunk, and the final record proves both chunks
+    # succeeded (all 3 bits set).
+    assert _dispatched_observation_setex_calls(mock_cache_empty) == []
+    progress_calls = _progress_setex_calls(mock_cache_empty)
+    assert len(progress_calls) == 2
+    assert progress_calls[-1].kwargs["value"][8:] == bytes([0b00000111])
 
 
 @pytest.mark.asyncio
@@ -330,7 +363,11 @@ async def test_batch_400_fallback_uses_a_fresh_client_per_item(
 
     # 1 client for the failed bulk attempt + 1 fresh client per fallback item
     assert len(created_clients) == 4
-    assert len(_dispatched_observation_setex_calls(mock_cache_empty)) == 3
+    assert _dispatched_observation_setex_calls(mock_cache_empty) == []
+    # All 3 items delivered individually, recorded in one progress flush
+    progress_calls = _progress_setex_calls(mock_cache_empty)
+    assert len(progress_calls) == 1
+    assert progress_calls[-1].kwargs["value"][8:] == bytes([0b00000111])
 
 
 @pytest.mark.asyncio
@@ -405,11 +442,11 @@ async def test_batch_items_cached_with_batch_ttl_not_single_item_ttl(
     mock_erclient_class,
     mock_pubsub_client,
 ):
-    # I-cache-TTL regression test: batch-delivered items must be cached with
-    # DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL (>= the 24h PubSub retry
-    # window), not the 1h single-item TTL - otherwise a redelivered envelope
-    # can silently re-post already-delivered items once the cache expires
-    # mid-retry-window.
+    # I-cache-TTL regression test: the per-envelope progress record must be
+    # cached with DISPATCHED_BATCH_PROGRESS_CACHE_TTL (>= the 24h PubSub
+    # retry window), not a shorter single-item TTL - otherwise a redelivered
+    # envelope can silently re-post already-delivered items once the record
+    # expires mid-retry-window.
     mocker.patch("core.utils._cache_db", mock_cache_empty)
     mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
     mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
@@ -417,15 +454,15 @@ async def test_batch_items_cached_with_batch_ttl_not_single_item_ttl(
 
     await process_request(_make_batch_request(mocker, items_count=3))
 
-    setex_calls = _dispatched_observation_setex_calls(mock_cache_empty)
-    assert len(setex_calls) == 3
+    setex_calls = _progress_setex_calls(mock_cache_empty)
+    assert len(setex_calls) == 1
     for call in setex_calls:
-        assert call.kwargs["time"] == settings.DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL
-        assert settings.DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL >= settings.MAX_EVENT_AGE_SECONDS
+        assert call.kwargs["time"] == settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL
+        assert settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL >= settings.MAX_EVENT_AGE_SECONDS
 
 
 @pytest.mark.asyncio
-async def test_batch_items_cached_as_sentinel_not_full_observation(
+async def test_batch_items_cached_as_compact_bitmap_not_per_item_keys(
     mocker,
     mock_cache_empty,
     mock_gundi_client_v2_class,
@@ -433,11 +470,10 @@ async def test_batch_items_cached_as_sentinel_not_full_observation(
     mock_pubsub_client,
 ):
     # Memory regression test: at 24h+ TTLs with one key per observation per
-    # destination, this cache dominates Redis during large backfills. Batch
-    # entries are only ever existence-checked (is_observation_dispatched) -
-    # ER bulk responses carry no per-item IDs, so there is no external_id
-    # worth storing - so they must be written as a 1-byte sentinel, not the
-    # full DispatchedObservation JSON.
+    # destination, this cache used to dominate Redis during large backfills
+    # (see the 2026-08-05 incident: 33.7M keys, 10 GB). Delivery is now
+    # recorded in ONE compact fingerprint+bitmap record per envelope instead
+    # of N per-item sentinel keys.
     mocker.patch("core.utils._cache_db", mock_cache_empty)
     mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
     mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
@@ -445,10 +481,14 @@ async def test_batch_items_cached_as_sentinel_not_full_observation(
 
     await process_request(_make_batch_request(mocker, items_count=3))
 
-    setex_calls = _dispatched_observation_setex_calls(mock_cache_empty)
-    assert len(setex_calls) == 3
-    for call in setex_calls:
-        assert call.kwargs["value"] == "1"
+    assert _dispatched_observation_setex_calls(mock_cache_empty) == []
+    setex_calls = _progress_setex_calls(mock_cache_empty)
+    assert len(setex_calls) == 1
+    value = setex_calls[0].kwargs["value"]
+    assert isinstance(value, bytes)
+    # 8-byte fingerprint + 1-byte bitmap for 3 items - far smaller than N
+    # per-item JSON records.
+    assert len(value) == 9
 
 
 @pytest.mark.asyncio
@@ -491,3 +531,283 @@ async def test_too_old_batch_publishes_dead_lettered_notice(
     from gundi_core.schemas.v2 import LogLevel
     assert event.payload.level == LogLevel.ERROR
     assert call_kwargs["topic_name"] == settings.DISPATCHER_EVENTS_TOPIC
+
+
+@pytest.mark.asyncio
+async def test_batch_writes_one_progress_record_instead_of_per_item_keys(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert _dispatched_observation_setex_calls(mock_cache_empty) == []
+    calls = _progress_setex_calls(mock_cache_empty)
+    assert len(calls) == 1
+    assert calls[0].kwargs["time"] == settings.DISPATCHED_BATCH_PROGRESS_CACHE_TTL
+    assert calls[0].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_reads_progress_once_not_per_item(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=25))
+
+    progress_reads = [
+        call for call in mock_cache_empty.get.call_args_list
+        if str(call.args[0]).startswith("batch_progress.")
+    ]
+    assert len(progress_reads) == 1
+    assert not any(
+        str(call.args[0]).startswith("dispatched_observation.")
+        for call in mock_cache_empty.get.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_skips_items_already_marked_in_bitmap(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # Leading None is get_integration_details' own config-cache miss.
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, _progress_value(3, {0}))
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 2
+    # The flush unions the pre-existing bit with the newly delivered ones
+    assert _progress_setex_calls(mock_cache)[-1].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_fully_delivered_posts_nothing_but_still_publishes(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, _progress_value(3, {0, 1, 2}))
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert not mock_erclient_class.return_value._post.called
+    # The original attempt may have died after recording progress and before
+    # publishing, so the delivered event must still go out for ALL items.
+    assert mock_pubsub_client.PublisherClient.return_value.publish.called
+
+
+@pytest.mark.asyncio
+async def test_batch_fingerprint_mismatch_reposts_everything(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    # A record whose bits are all set, but computed over DIFFERENT item ids -
+    # positional bits are meaningless, so it must fail open.
+    stale = _progress_value(3, {0, 1, 2}, gundi_ids=["other-0", "other-1", "other-2"])
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, stale)
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 3
+
+
+@pytest.mark.asyncio
+async def test_batch_flushes_progress_per_chunk(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "ER_BULK_SIZE", 2)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    calls = _progress_setex_calls(mock_cache_empty)
+    assert len(calls) == 2  # one per chunk
+    assert calls[0].kwargs["value"][8:] == bytes([0b00000011])
+    assert calls[1].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_persists_progress_before_raising_on_transient_error(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "ER_BULK_SIZE", 2)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+    from tests.conftest import async_return
+    err = ERClientException("ER error ON POST: service unavailable")
+    err.status_code = 503
+    # First chunk's bulk _post must return an awaitable (a coroutine, via
+    # async_return) to represent success - a bare None isn't awaitable and
+    # would make chunk 1 itself raise, defeating the point of this test.
+    mock_erclient_class.return_value._post.side_effect = [async_return(None), err]
+
+    with pytest.raises(Exception):
+        await process_request(_make_batch_request(mocker, items_count=3))
+
+    # Chunk 1's progress must be durable before the nack, or redelivery
+    # re-posts it.
+    calls = _progress_setex_calls(mock_cache_empty)
+    assert len(calls) == 1
+    assert calls[0].kwargs["value"][8:] == bytes([0b00000011])
+
+
+@pytest.mark.asyncio
+async def test_batch_permanent_error_marks_only_individually_delivered_items(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+    from tests.conftest import async_return
+    bulk_err = ERClientException("ER error ON POST: bad request")
+    bulk_err.status_code = 400
+    mock_erclient_class.return_value._post.side_effect = bulk_err
+    item_err = ERClientException("ER error: bad record")
+    item_err.status_code = 400
+    # Successful per-item posts must be awaitables (async_return), not bare
+    # None - a bare None isn't awaitable and would make every fallback item
+    # raise TypeError, masking the one genuine per-item failure this test
+    # is about.
+    mock_erclient_class.return_value.post_sensor_observation.side_effect = [
+        async_return(None), item_err, async_return(None)
+    ]
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    # Items 0 and 2 succeeded individually; item 1 failed and keeps its bit
+    # unset so redelivery retries it.
+    assert _progress_setex_calls(mock_cache_empty)[-1].kwargs["value"][8:] == bytes([0b00000101])
+
+
+@pytest.mark.asyncio
+async def test_batch_falls_back_to_legacy_per_item_keys(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+    dispatched_event,
+):
+    # No progress record; legacy key present for item 0 only. Order of gets:
+    # config cache, progress, then one per item for the legacy sweep.
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = (None, None, dispatched_event.json(), None, None)
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", True)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 2
+    # The envelope migrates to the new format, including the legacy-derived bit
+    assert _progress_setex_calls(mock_cache)[-1].kwargs["value"][8:] == bytes([0b00000111])
+
+
+@pytest.mark.asyncio
+async def test_batch_does_not_read_legacy_keys_when_fallback_disabled(
+    mocker,
+    mock_cache_empty,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mocker.patch("core.utils._cache_db", mock_cache_empty)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))
+
+    assert not any(
+        str(call.args[0]).startswith("dispatched_observation.")
+        for call in mock_cache_empty.get.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_delivers_normally_when_cache_read_and_write_fail(
+    mocker,
+    mock_gundi_client_v2_class,
+    mock_erclient_class,
+    mock_pubsub_client,
+):
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.return_value = None
+    mock_cache.setex.side_effect = RuntimeError("redis down")
+    mocker.patch("core.utils._cache_db", mock_cache)
+    mocker.patch("core.utils.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("core.dispatchers.TokenCachingAsyncERClient", mock_erclient_class)
+    mocker.patch("core.utils.pubsub", mock_pubsub_client)
+    mocker.patch.object(settings, "BATCH_DEDUP_LEGACY_FALLBACK_ENABLED", False)
+
+    await process_request(_make_batch_request(mocker, items_count=3))  # must not raise
+
+    posted = mock_erclient_class.return_value._post.call_args.kwargs["payload"]
+    assert len(posted) == 3


### PR DESCRIPTION
## Why

Prod Redis (`sintegrate-4bb07e9c`, 10 GB, project `cdip-prod1-78ca`) filled completely on 2026-08-05. Sampling db3 — the ER dispatcher's keyspace — found:

- **33.7M keys / 10.00 GB of 10 GB**, 99.9% `dispatched_observation.*`, ~223 B each, TTL histogram peaking in the 24–26h bucket
- **96% belonged to a single destination** (Wildlife Dynamics), whose topic went ~400 → ~800K messages/day on 08-04
- Growth ~1.7M keys/hour with no plateau; projected steady state ~42M keys / ~9.4 GB for db3 alone
- At 100% with `maxmemory-policy=volatile-lru`, Redis was evicting the very idempotency keys the TTL exists to protect

The batch path wrote one key per observation per destination, so resident memory is `observation_rate × TTL` with no steady state that fits the instance. The 25h TTL is **correct and unchanged** — it must exceed `MAX_EVENT_AGE_SECONDS` (86400), or a PubSub redelivery after expiry re-posts delivered items. The defect is cardinality, not lifetime.

Ruled out by inspection: the `ef7e398` TTL-env-var fix had no prod effect (prod sets neither var, so the value was the 3600 default before and after), and ER token caching is ~1 key per destination. The `5b93c84` sentinel fix helped (223 B vs ~380 B) but 2–2.5× cannot absorb a 25× TTL.

## What

One progress record per envelope instead of N keys:

```
KEY    batch_progress.{batch_id}.{destination_id}.{sha256(provider_key)[:8]}
VALUE  bytes 0..7  8-byte fingerprint of the ordered gundi_id sequence
       bytes 8..   bitmap, bit i = batch.items[i] delivered
TTL    90000s (unchanged)
```

| | Before | After |
|---|---|---|
| Keys resident | 33.7M (heading for ~42M) | ~830K |
| db3 memory | ~9.4 GB projected | ~0.1–0.2 GB |
| Reads per envelope | N `GET` | 1 `GET` |
| Writes per envelope | N `SETEX` | ~1 `SET` per chunk |

Two details are load-bearing:

- **`provider_key` is in the key** because cdip-routing groups items per `(destination, effective_provider_key)`, so one `batch_id` + `destination_id` legitimately yields several envelopes with disjoint item sets. It's hashed because it's free-form and may contain `.` or `:`.
- **The fingerprint** exists because cdip-routing can re-publish the same `batch_id` with a *different* item list (it publishes some groups then raises, and per-item transform failures shrink the batch). Without it, positional bit `i` from attempt 1 would be read as authoritative for a different observation in attempt 2 — silently skipping an undelivered item. A mismatch fails open and re-posts instead. The encoding is length-prefixed rather than delimiter-joined: `gundi_id` is `Union[UUID, str]`, so a `"|"` inside an id would let `["a|b","c"]` and `["a","b|c"]` collide, and a false *match* does not fail open.

Throughout, duplicates are the accepted failure currency; a skipped observation is not. Every ambiguous case — mismatch, truncation, Redis error, lost update under concurrent redelivery — fails open toward re-posting.

Untouched by design: the single-item path keeps its per-observation keys at the 1h TTL, because `get_dispatched_observation` needs the stored `external_id` to resolve `related_to` for attachment delivery.

## Rollout — ordering matters

A transitional `BATCH_DEDUP_LEGACY_FALLBACK_ENABLED` (default `true`) dual-read stops envelopes in flight at deploy from being re-posted wholesale. Full runbook in `docs/rollout-envelope-dedup.md`:

1. Scale the instance up — **independent of this PR and more urgent**; the old scheme is what's deployed and the instance is at 100%
2. Deploy with the flag on
3. Wait ≥25h (longer than `MAX_EVENT_AGE_SECONDS`)
4. Set the flag `false`
5. Optionally purge leftover `dispatched_observation.*`
6. Scale back down
7. Follow-up PR: delete the fallback, `mark_observation_dispatched`, and `DISPATCHED_OBSERVATIONS_BATCH_CACHE_TTL`

**Do not purge before step 4** — the fallback reads those keys, and purging early recreates the duplicate burst the window prevents.

`dedup_source` on the dispatch span reports `none` (first delivery — the common case), `batch_progress` (redelivery), `unusable_record` (fingerprint mismatch or truncation), or `legacy` (pre-deploy envelope). Watch `legacy` decay to zero across the window.

## Tests

194 → 225 (31 net new). `conftest.py` now imports `ObservationsBatchTransformedER` so a stale `gundi-core` fails the suite loudly — with 1.12.0 installed instead of the pinned 1.13.0, six test files silently failed *collection* while the run still reported green, which masked verification during development.

Covered: envelope-relative bit indexing, union-preserving `delivered`, one flush per chunk with none in the transient branch (so a nacked envelope doesn't re-post completed chunks), the 4xx per-item fallback marking only individually-successful items, fingerprint mismatch re-posting everything, the legacy dual-read, empty-batch no-op with no portal lookup, and Redis failing on both read and write.

## Known limitation

The progress value is read-modify-written, so two workers handling the same redelivered envelope can clobber bits. Worst case is duplicates — `delivered` is only ever seeded from evidence of real delivery and only added to after a successful send, so a lost update can drop a bit but never invent one. A Lua OR-merge is noted as a follow-up if the rate proves material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W259woydNQv2tMy1d7qdRW